### PR TITLE
cafe24 액세스 토큰 재발급 api를 구현한다.

### DIFF
--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/common/handler/GlobalExceptionHandler.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/common/handler/GlobalExceptionHandler.java
@@ -56,6 +56,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 	@ExceptionHandler(HttpClientErrorException.class)
 	public ResponseEntity<Object> handleHttpClientErrorException(HttpClientErrorException ex) {
+		StringBuilder sb = new StringBuilder();
+		if (ex.getResponseHeaders() != null) {
+			sb.append("Http Status Code: [").append(ex.getStatusCode()).append("]\n");
+			sb.append("[Request Info] \n");
+			ex.getResponseHeaders().forEach((key, value) -> sb.append(key).append(": ").append(value).append("\n"));
+			sb.append("[Response Body] \n").append(ex.getResponseBodyAsString());
+		}
+		log.warn(sb.toString());
 		return handleExceptionInternal(CommonErrorCode.OUTER_CLIENT_REQUEST_ERROR);
 	}
 

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/common/handler/GlobalExceptionHandler.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/common/handler/GlobalExceptionHandler.java
@@ -62,8 +62,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 			sb.append("[Request Info] \n");
 			ex.getResponseHeaders().forEach((key, value) -> sb.append(key).append(": ").append(value).append("\n"));
 			sb.append("[Response Body] \n").append(ex.getResponseBodyAsString());
+			log.warn(sb.toString());
 		}
-		log.warn(sb.toString());
 		return handleExceptionInternal(CommonErrorCode.OUTER_CLIENT_REQUEST_ERROR);
 	}
 

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/ShopUseCase.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/ShopUseCase.java
@@ -4,4 +4,6 @@ import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.response.Ge
 
 public interface ShopUseCase {
 	GetCafe24AccessTokenResponse getCafe24AccessToken(String mallId, String authCode);
+
+	GetCafe24AccessTokenResponse reissueCafe24AccessToken(String mallId, String refreshToken);
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/ShopUseCase.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/ShopUseCase.java
@@ -5,5 +5,8 @@ import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.response.Ge
 public interface ShopUseCase {
 	GetCafe24AccessTokenResponse getCafe24AccessToken(String mallId, String authCode);
 
+	/**
+	 * 만약 refresh token이 유효하지 않거나 만료되었을 경우, INVALID_OR_EXPIRED_REFRESH_TOKEN error를 발생시킨다.
+	 */
 	GetCafe24AccessTokenResponse reissueCafe24AccessToken(String mallId, String refreshToken);
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/ShopUseCaseImpl.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/ShopUseCaseImpl.java
@@ -1,12 +1,15 @@
 package com.romanticpipe.reviewcanvas.domain.shop.application.usecase;
 
+import com.romanticpipe.reviewcanvas.cafe24.Cafe24ErrorCode;
 import com.romanticpipe.reviewcanvas.cafe24.Cafe24FormUrlencodedFactory;
 import com.romanticpipe.reviewcanvas.cafe24.authentication.Cafe24AccessToken;
 import com.romanticpipe.reviewcanvas.cafe24.authentication.Cafe24AuthenticationClient;
 import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.response.GetCafe24AccessTokenResponse;
+import com.romanticpipe.reviewcanvas.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
 
 @Component
 @RequiredArgsConstructor
@@ -24,7 +27,14 @@ public class ShopUseCaseImpl implements ShopUseCase {
 	@Override
 	public GetCafe24AccessTokenResponse reissueCafe24AccessToken(String mallId, String refreshToken) {
 		MultiValueMap<String, String> requestParam = Cafe24FormUrlencodedFactory.reissueCafe24AccessToken(refreshToken);
-		Cafe24AccessToken cafe24AccessToken = cafe24AuthenticationClient.reissueAccessToken(mallId, requestParam);
-		return GetCafe24AccessTokenResponse.from(cafe24AccessToken);
+		try {
+			Cafe24AccessToken cafe24AccessToken = cafe24AuthenticationClient.reissueAccessToken(mallId, requestParam);
+			return GetCafe24AccessTokenResponse.from(cafe24AccessToken);
+		} catch (HttpClientErrorException ex) {
+			if (ex.getResponseBodyAsString().contains("\"error\":\"invalid_grant\"")) {
+				throw new BusinessException(Cafe24ErrorCode.INVALID_OR_EXPIRED_REFRESH_TOKEN);
+			}
+			throw ex;
+		}
 	}
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/ShopUseCaseImpl.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/ShopUseCaseImpl.java
@@ -20,4 +20,11 @@ public class ShopUseCaseImpl implements ShopUseCase {
 		Cafe24AccessToken cafe24AccessToken = cafe24AuthenticationClient.getAccessToken(mallId, requestParam);
 		return GetCafe24AccessTokenResponse.from(cafe24AccessToken);
 	}
+
+	@Override
+	public GetCafe24AccessTokenResponse reissueCafe24AccessToken(String mallId, String refreshToken) {
+		MultiValueMap<String, String> requestParam = Cafe24FormUrlencodedFactory.reissueCafe24AccessToken(refreshToken);
+		Cafe24AccessToken cafe24AccessToken = cafe24AuthenticationClient.reissueAccessToken(mallId, requestParam);
+		return GetCafe24AccessTokenResponse.from(cafe24AccessToken);
+	}
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/ShopApi.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/ShopApi.java
@@ -31,4 +31,23 @@ public interface ShopApi {
 		@Schema(name = "mall id", description = "쇼핑몰의 아이디") @RequestParam(required = true) String mallId,
 		@Schema(name = "authorization code", description = "인증 코드") @RequestParam(required = true) String authCode
 	);
+
+	@Operation(summary = "cafe24 액세스 토큰 재발급", description = "refresh token으로 cafe24 access token을 재발급한다. " +
+		"[주의]: 해당 api를 호출하면 refresh token도 항상 재발급됩니다. "
+		+ "https://developers.cafe24.com/app/front/app/develop/oauth/retoken")
+	@ApiResponses(value = {
+		@ApiResponse(
+			responseCode = "200",
+			description = "성공적으로 액세스 토큰을 재발급했습니다."),
+		@ApiResponse(
+			responseCode = "400",
+			description = "C003: 외부 API 호출 중 오류가 발생했습니다.",
+			content = @Content(schema = @Schema(hidden = true))),
+	})
+	@GetMapping("/cafe24/reissue-access-token")
+	ResponseEntity<SuccessResponse<GetCafe24AccessTokenResponse>> reissueCafe24AccessToken(
+		@Schema(name = "mall id", description = "쇼핑몰의 아이디") @RequestParam(required = true) String mallId,
+		@Schema(name = "refresh token", description = "cafe24 refresh token")
+		@RequestParam(required = true) String refreshToken
+	);
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/ShopController.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/ShopController.java
@@ -28,4 +28,14 @@ public class ShopController implements ShopApi {
 		GetCafe24AccessTokenResponse response = shopUseCase.getCafe24AccessToken(mallId, authCode);
 		return SuccessResponse.of(response).asHttp(HttpStatus.OK);
 	}
+
+	@Override
+	@GetMapping("/cafe24/reissue-access-token")
+	public ResponseEntity<SuccessResponse<GetCafe24AccessTokenResponse>> reissueCafe24AccessToken(
+		@RequestParam(required = true) String mallId,
+		@RequestParam(required = true) String refreshToken
+	) {
+		GetCafe24AccessTokenResponse response = shopUseCase.reissueCafe24AccessToken(mallId, refreshToken);
+		return SuccessResponse.of(response).asHttp(HttpStatus.OK);
+	}
 }

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24ErrorCode.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24ErrorCode.java
@@ -1,0 +1,29 @@
+package com.romanticpipe.reviewcanvas.cafe24;
+
+import com.romanticpipe.reviewcanvas.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum Cafe24ErrorCode implements ErrorCode {
+
+	INVALID_OR_EXPIRED_REFRESH_TOKEN(400, "CA001", "cafe24 refresh token이 유효하지 않거나 만료되었습니다.");
+
+	private final int status;
+	private final String code;
+	private final String message;
+
+	@Override
+	public int getStatus() {
+		return status;
+	}
+
+	@Override
+	public String getCode() {
+		return code;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24FormUrlencodedFactory.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24FormUrlencodedFactory.java
@@ -16,4 +16,11 @@ public class Cafe24FormUrlencodedFactory {
 		requestBody.put("redirect_uri", List.of(REDIRECT_URI));
 		return requestBody;
 	}
+
+	public static MultiValueMap<String, String> reissueCafe24AccessToken(String refreshToken) {
+		MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+		requestBody.put("refresh_token", List.of(refreshToken));
+		requestBody.put("grant_type", List.of("refresh_token"));
+		return requestBody;
+	}
 }

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/authentication/Cafe24AuthenticationClient.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/authentication/Cafe24AuthenticationClient.java
@@ -15,4 +15,7 @@ public interface Cafe24AuthenticationClient {
 	Cafe24AccessToken getAccessToken(@PathVariable String mallId,
 									 @RequestParam MultiValueMap<String, String> requestParam);
 
+	@PostExchange(value = "/oauth/token", contentType = "application/x-www-form-urlencoded")
+	Cafe24AccessToken reissueAccessToken(@PathVariable String mallId,
+										 @RequestParam MultiValueMap<String, String> requestParam);
 }

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/config/RestClientLoggingInterceptor.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/config/RestClientLoggingInterceptor.java
@@ -1,6 +1,5 @@
 package com.romanticpipe.reviewcanvas.config;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
@@ -10,7 +9,6 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-@Slf4j
 @Component
 public class RestClientLoggingInterceptor implements ClientHttpRequestInterceptor {
 

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/config/RestClientLoggingInterceptor.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/config/RestClientLoggingInterceptor.java
@@ -1,6 +1,7 @@
 package com.romanticpipe.reviewcanvas.config;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
@@ -8,8 +9,6 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -19,23 +18,17 @@ public class RestClientLoggingInterceptor implements ClientHttpRequestIntercepto
 	public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
 		throws IOException {
 		ClientHttpResponse clientHttpResponse = execution.execute(request, body);
+
 		if (!clientHttpResponse.getStatusCode().is2xxSuccessful()) {
-			logError(request, clientHttpResponse);
+			replaceResponseHeaders(request, clientHttpResponse.getHeaders());
 		}
 		return clientHttpResponse;
 	}
 
-	private void logError(HttpRequest request, ClientHttpResponse response) throws IOException {
-		StringBuilder requestInfo = new StringBuilder()
-			.append("[").append(request.getMethod()).append("] ").append(request.getURI()).append(" Headers: ")
-			.append(request.getHeaders().entrySet().stream()
-				.map(entry -> entry.getKey() + ": " + entry.getValue())
-				.collect(Collectors.joining(", ")));
-
-		StringBuilder responseInfo = new StringBuilder()
-			.append(response.getStatusCode()).append(" ")
-			.append(new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8));
-
-		log.warn("[Request]: {} [Response]: {}", requestInfo, responseInfo);
+	private void replaceResponseHeaders(HttpRequest request, HttpHeaders responseHeaders) {
+		responseHeaders.clear();
+		responseHeaders.add("URL", request.getURI().toString());
+		responseHeaders.add("Method", request.getMethod().toString());
+		responseHeaders.addAll(request.getHeaders());
 	}
 }

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/config/RestClientLoggingInterceptor.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/config/RestClientLoggingInterceptor.java
@@ -36,6 +36,6 @@ public class RestClientLoggingInterceptor implements ClientHttpRequestIntercepto
 			.append(response.getStatusCode()).append(" ")
 			.append(new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8));
 
-		log.error("[Request]: {} [Response]: {}", requestInfo, responseInfo);
+		log.warn("[Request]: {} [Response]: {}", requestInfo, responseInfo);
 	}
 }


### PR DESCRIPTION
### 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

- cafe24 액세스 토큰 재발급 api 구현

### ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

- restclient 요청 실패시 error log level을 error -> warn으로 수정했습니다.

### 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?

없습니다.

### 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요

없습니다.

### 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?

없습니다.
