### PR TITLE
feat(RVCV-98): 리뷰 노출 항목의 title 조회 API를 구현한다.

### DIFF
--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/aplication/usecase/ShopAdminUseCase.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/aplication/usecase/ShopAdminUseCase.java
@@ -1,15 +1,12 @@
 package com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase;
 
-import org.springframework.web.multipart.MultipartFile;
-
 import com.romanticpipe.reviewcanvas.domain.AdminInterface;
 import com.romanticpipe.reviewcanvas.domain.Role;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.request.SignUpRequest;
 import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.CheckLoginResponse;
 import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.GetReviewVisibilityTitleResponse;
 import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.LoginResponse;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface ShopAdminUseCase {
 
@@ -22,5 +19,6 @@ public interface ShopAdminUseCase {
 	CheckLoginResponse checkLoginSession(AdminInterface admin);
 
 	LoginResponse reissuedAccessToken(String accessToken);
+
 	GetReviewVisibilityTitleResponse getReviewVisibilityTitle();
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/aplication/usecase/ShopAdminUseCase.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/aplication/usecase/ShopAdminUseCase.java
@@ -1,8 +1,10 @@
 package com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase;
 
-import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.request.SignUpRequest;
-import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.LoginResponse;
 import org.springframework.web.multipart.MultipartFile;
+
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.request.SignUpRequest;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.GetReviewVisibilityTitleResponse;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.LoginResponse;
 
 public interface ShopAdminUseCase {
 
@@ -10,4 +12,5 @@ public interface ShopAdminUseCase {
 
 	void signUp(SignUpRequest signUpRequest, MultipartFile logoImage);
 
+	GetReviewVisibilityTitleResponse getReviewVisibilityTitle();
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/aplication/usecase/ShopAdminUseCaseImpl.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/aplication/usecase/ShopAdminUseCaseImpl.java
@@ -10,6 +10,7 @@ import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.request
 import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.GetReviewVisibilityTitleResponse;
 import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.LoginResponse;
 import com.romanticpipe.reviewcanvas.service.ShopAdminCreator;
+import com.romanticpipe.reviewcanvas.service.ShopAdminReader;
 import com.romanticpipe.reviewcanvas.service.ShopAdminValidator;
 
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ class ShopAdminUseCaseImpl implements ShopAdminUseCase {
 
 	private final ShopAdminValidator shopAdminValidator;
 	private final ShopAdminCreator shopAdminCreator;
+	private final ShopAdminReader shopAdminReader;
 
 	@Override
 	@Transactional(readOnly = true)
@@ -62,6 +64,6 @@ class ShopAdminUseCaseImpl implements ShopAdminUseCase {
 	@Override
 	@Transactional(readOnly = true)
 	public GetReviewVisibilityTitleResponse getReviewVisibilityTitle() {
-		return null;
+		return GetReviewVisibilityTitleResponse.from(shopAdminReader.getReviewVisibilityTitle());
 	}
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/aplication/usecase/ShopAdminUseCaseImpl.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/aplication/usecase/ShopAdminUseCaseImpl.java
@@ -1,15 +1,18 @@
 package com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase;
 
-import com.romanticpipe.reviewcanvas.domain.ReviewVisibility;
-import com.romanticpipe.reviewcanvas.domain.ShopAdmin;
-import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.request.SignUpRequest;
-import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.LoginResponse;
-import com.romanticpipe.reviewcanvas.service.ShopAdminCreator;
-import com.romanticpipe.reviewcanvas.service.ShopAdminValidator;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import com.romanticpipe.reviewcanvas.domain.ReviewVisibility;
+import com.romanticpipe.reviewcanvas.domain.ShopAdmin;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.request.SignUpRequest;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.GetReviewVisibilityTitleResponse;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.LoginResponse;
+import com.romanticpipe.reviewcanvas.service.ShopAdminCreator;
+import com.romanticpipe.reviewcanvas.service.ShopAdminValidator;
+
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
@@ -44,7 +47,7 @@ class ShopAdminUseCaseImpl implements ShopAdminUseCase {
 			.email(signUpRequest.email())
 			.password(signUpRequest.password())
 			.name(signUpRequest.name())
-//			.logoImageUrl(signUpRequest.logoImageUrl())
+			//			.logoImageUrl(signUpRequest.logoImageUrl())
 			.mallNumber(signUpRequest.mallNumber())
 			.phoneNumber(signUpRequest.phoneNumber())
 			.approveStatus(false)
@@ -54,5 +57,11 @@ class ShopAdminUseCaseImpl implements ShopAdminUseCase {
 			.build();
 
 		shopAdminCreator.signUp(shopAdmin);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public GetReviewVisibilityTitleResponse getReviewVisibilityTitle() {
+		return null;
 	}
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/aplication/usecase/ShopAdminUseCaseImpl.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/aplication/usecase/ShopAdminUseCaseImpl.java
@@ -3,10 +3,6 @@ package com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase;
 import com.romanticpipe.reviewcanvas.common.security.TokenProvider;
 import com.romanticpipe.reviewcanvas.domain.AdminAuth;
 import com.romanticpipe.reviewcanvas.domain.AdminInterface;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.romanticpipe.reviewcanvas.domain.ReviewVisibility;
 import com.romanticpipe.reviewcanvas.domain.Role;
 import com.romanticpipe.reviewcanvas.domain.ShopAdmin;
@@ -26,7 +22,6 @@ import com.romanticpipe.reviewcanvas.service.SuperAdminValidator;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -91,7 +86,6 @@ class ShopAdminUseCaseImpl implements ShopAdminUseCase {
 			.email(signUpRequest.email())
 			.password(passwordEncoder.encode(signUpRequest.password()))
 			.name(signUpRequest.name())
-			//			.logoImageUrl(signUpRequest.logoImageUrl())
 			.mallNumber(signUpRequest.mallNumber())
 			.phoneNumber(signUpRequest.phoneNumber())
 			.approveStatus(false)

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/aplication/usecase/ShopAdminUseCaseImpl.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/aplication/usecase/ShopAdminUseCaseImpl.java
@@ -9,8 +9,8 @@ import com.romanticpipe.reviewcanvas.domain.ShopAdmin;
 import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.request.SignUpRequest;
 import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.GetReviewVisibilityTitleResponse;
 import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.LoginResponse;
+import com.romanticpipe.reviewcanvas.service.ReviewVisibilityReader;
 import com.romanticpipe.reviewcanvas.service.ShopAdminCreator;
-import com.romanticpipe.reviewcanvas.service.ShopAdminReader;
 import com.romanticpipe.reviewcanvas.service.ShopAdminValidator;
 
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,7 @@ class ShopAdminUseCaseImpl implements ShopAdminUseCase {
 
 	private final ShopAdminValidator shopAdminValidator;
 	private final ShopAdminCreator shopAdminCreator;
-	private final ShopAdminReader shopAdminReader;
+	private final ReviewVisibilityReader reviewVisibilityReader;
 
 	@Override
 	@Transactional(readOnly = true)
@@ -64,6 +64,6 @@ class ShopAdminUseCaseImpl implements ShopAdminUseCase {
 	@Override
 	@Transactional(readOnly = true)
 	public GetReviewVisibilityTitleResponse getReviewVisibilityTitle() {
-		return GetReviewVisibilityTitleResponse.from(shopAdminReader.getReviewVisibilityTitle());
+		return GetReviewVisibilityTitleResponse.from(reviewVisibilityReader.getReviewVisibilityTitle());
 	}
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/aplication/usecase/response/GetReviewVisibilityTitleResponse.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/aplication/usecase/response/GetReviewVisibilityTitleResponse.java
@@ -1,0 +1,21 @@
+package com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response;
+
+import java.util.Objects;
+
+import com.romanticpipe.reviewcanvas.domain.ReviewVisibility;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "GetReviewVisibilityTitleResponse", description = "리뷰 노출 항목 title 조회 응답")
+public record GetReviewVisibilityTitleResponse(
+	@Schema(description = "Review Title Active", requiredMode = Schema.RequiredMode.REQUIRED)
+	String title) {
+
+	public GetReviewVisibilityTitleResponse {
+		Objects.requireNonNull(title);
+	}
+
+	public static GetReviewVisibilityTitleResponse from(ReviewVisibility reviewVisibility) {
+		return new GetReviewVisibilityTitleResponse(reviewVisibility.getClass().getFields().toString());
+	}
+}

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/aplication/usecase/response/GetReviewVisibilityTitleResponse.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/aplication/usecase/response/GetReviewVisibilityTitleResponse.java
@@ -1,21 +1,20 @@
 package com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response;
 
+import java.util.List;
 import java.util.Objects;
-
-import com.romanticpipe.reviewcanvas.domain.ReviewVisibility;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "GetReviewVisibilityTitleResponse", description = "리뷰 노출 항목 title 조회 응답")
 public record GetReviewVisibilityTitleResponse(
 	@Schema(description = "Review Title Active", requiredMode = Schema.RequiredMode.REQUIRED)
-	String title) {
+	List<String> titles) {
 
 	public GetReviewVisibilityTitleResponse {
-		Objects.requireNonNull(title);
+		Objects.requireNonNull(titles);
 	}
 
-	public static GetReviewVisibilityTitleResponse from(ReviewVisibility reviewVisibility) {
-		return new GetReviewVisibilityTitleResponse(reviewVisibility.getClass().getFields().toString());
+	public static GetReviewVisibilityTitleResponse from(List<String> titles) {
+		return new GetReviewVisibilityTitleResponse(titles);
 	}
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/presentation/v1/ShopAdminApi.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/presentation/v1/ShopAdminApi.java
@@ -1,5 +1,14 @@
 package com.romanticpipe.reviewcanvas.domain.shopadmin.presentation.v1;
 
+import com.romanticpipe.reviewcanvas.common.dto.SuccessResponse;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.request.SignUpRequest;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.GetReviewVisibilityTitleResponse;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.LoginResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,17 +16,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-
-import com.romanticpipe.reviewcanvas.common.dto.SuccessResponse;
-import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.request.SignUpRequest;
-import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.GetReviewVisibilityTitleResponse;
-import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.LoginResponse;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 
 @Tag(name = "ShopAdmin", description = "샵 어드민 API")
 interface ShopAdminApi {
@@ -53,6 +51,6 @@ interface ShopAdminApi {
 			responseCode = "200",
 			description = "성공적으로 리뷰 노출 항목 title 조회가 완료되었습니다.")
 	})
-	@GetMapping(value = "/shopadmin/review-visibility/titles")
+	@GetMapping(value = "/shop-admin/review-visibility/titles")
 	ResponseEntity<SuccessResponse<GetReviewVisibilityTitleResponse>> getReviewVisibilityTitle();
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/presentation/v1/ShopAdminApi.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/presentation/v1/ShopAdminApi.java
@@ -53,6 +53,6 @@ interface ShopAdminApi {
 			responseCode = "200",
 			description = "성공적으로 리뷰 노출 항목 title 조회가 완료되었습니다.")
 	})
-	@GetMapping(value = "/shopadmin/reviewVisibility/title")
+	@GetMapping(value = "/shopadmin/review-visibility/titles")
 	ResponseEntity<SuccessResponse<GetReviewVisibilityTitleResponse>> getReviewVisibilityTitle();
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/presentation/v1/ShopAdminApi.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/presentation/v1/ShopAdminApi.java
@@ -1,13 +1,5 @@
 package com.romanticpipe.reviewcanvas.domain.shopadmin.presentation.v1;
 
-import com.romanticpipe.reviewcanvas.common.dto.SuccessResponse;
-import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.request.SignUpRequest;
-import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.LoginResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,6 +7,17 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
+
+import com.romanticpipe.reviewcanvas.common.dto.SuccessResponse;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.request.SignUpRequest;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.GetReviewVisibilityTitleResponse;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.LoginResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 @Tag(name = "ShopAdmin", description = "샵 어드민 API")
 interface ShopAdminApi {
@@ -43,4 +46,13 @@ interface ShopAdminApi {
 		@Valid @RequestPart SignUpRequest signUpRequest,
 		@RequestParam MultipartFile logoImage
 	);
+
+	@Operation(summary = "리뷰 노출 항목 title 조회 API", description = "리뷰 노출 항목 title을 조회한다.")
+	@ApiResponses(value = {
+		@ApiResponse(
+			responseCode = "200",
+			description = "성공적으로 리뷰 노출 항목 title 조회가 완료되었습니다.")
+	})
+	@GetMapping(value = "/shopadmin/reviewVisibility/title")
+	ResponseEntity<SuccessResponse<GetReviewVisibilityTitleResponse>> getReviewVisibilityTitle();
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/presentation/v1/ShopAdminController.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/presentation/v1/ShopAdminController.java
@@ -1,5 +1,12 @@
 package com.romanticpipe.reviewcanvas.domain.shopadmin.presentation.v1;
 
+import com.romanticpipe.reviewcanvas.common.dto.SuccessResponse;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.ShopAdminUseCase;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.request.SignUpRequest;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.GetReviewVisibilityTitleResponse;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.LoginResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -10,15 +17,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import com.romanticpipe.reviewcanvas.common.dto.SuccessResponse;
-import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.ShopAdminUseCase;
-import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.request.SignUpRequest;
-import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.GetReviewVisibilityTitleResponse;
-import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.LoginResponse;
-
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -49,7 +47,7 @@ class ShopAdminController implements ShopAdminApi {
 	}
 
 	@Override
-	@GetMapping("/shopadmin/review-visibility/titles")
+	@GetMapping("/shop-admin/review-visibility/titles")
 	public ResponseEntity<SuccessResponse<GetReviewVisibilityTitleResponse>> getReviewVisibilityTitle() {
 		return SuccessResponse.of(
 			shopAdminUseCase.getReviewVisibilityTitle()

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/presentation/v1/ShopAdminController.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/presentation/v1/ShopAdminController.java
@@ -1,11 +1,5 @@
 package com.romanticpipe.reviewcanvas.domain.shopadmin.presentation.v1;
 
-import com.romanticpipe.reviewcanvas.common.dto.SuccessResponse;
-import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.ShopAdminUseCase;
-import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.request.SignUpRequest;
-import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.LoginResponse;
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +10,15 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import com.romanticpipe.reviewcanvas.common.dto.SuccessResponse;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.ShopAdminUseCase;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.request.SignUpRequest;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.GetReviewVisibilityTitleResponse;
+import com.romanticpipe.reviewcanvas.domain.shopadmin.aplication.usecase.response.LoginResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -43,5 +46,10 @@ class ShopAdminController implements ShopAdminApi {
 		@RequestParam MultipartFile logoImage) {
 		shopAdminUseCase.signUp(signUpRequest, logoImage);
 		return SuccessResponse.ofNoData().asHttp(HttpStatus.OK);
+	}
+
+	@Override
+	public ResponseEntity<SuccessResponse<GetReviewVisibilityTitleResponse>> getReviewVisibilityTitle() {
+		return null;
 	}
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/presentation/v1/ShopAdminController.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/presentation/v1/ShopAdminController.java
@@ -50,6 +50,8 @@ class ShopAdminController implements ShopAdminApi {
 
 	@Override
 	public ResponseEntity<SuccessResponse<GetReviewVisibilityTitleResponse>> getReviewVisibilityTitle() {
-		return null;
+		return SuccessResponse.of(
+			shopAdminUseCase.getReviewVisibilityTitle()
+		).asHttp(HttpStatus.OK);
 	}
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/presentation/v1/ShopAdminController.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shopadmin/presentation/v1/ShopAdminController.java
@@ -49,6 +49,7 @@ class ShopAdminController implements ShopAdminApi {
 	}
 
 	@Override
+	@GetMapping("/shopadmin/review-visibility/titles")
 	public ResponseEntity<SuccessResponse<GetReviewVisibilityTitleResponse>> getReviewVisibilityTitle() {
 		return SuccessResponse.of(
 			shopAdminUseCase.getReviewVisibilityTitle()

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/repository/ReviewVisibilityRepository.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/repository/ReviewVisibilityRepository.java
@@ -1,19 +1,18 @@
 package com.romanticpipe.reviewcanvas.repository;
 
-import java.util.List;
-
+import com.romanticpipe.reviewcanvas.domain.ReviewVisibility;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import com.romanticpipe.reviewcanvas.domain.ReviewVisibility;
+import java.util.List;
 
 public interface ReviewVisibilityRepository extends JpaRepository<ReviewVisibility, Long> {
 	@Query(
-		value = "SELECT COLUMN_NAME\n"
-			+ "FROM INFORMATION_SCHEMA.COLUMNS\n"
-			+ "WHERE TABLE_SCHEMA = 'review_canvas_db'\n"
-			+ "  AND TABLE_NAME = 'review_visibility'\n"
-			+ "  AND COLUMN_NAME NOT IN ('review_visibility_id')\n"
+		value = "SELECT COLUMN_NAME "
+			+ "FROM INFORMATION_SCHEMA.COLUMNS "
+			+ "WHERE TABLE_SCHEMA = 'review_canvas_db' "
+			+ "  AND TABLE_NAME = 'review_visibility' "
+			+ "  AND COLUMN_NAME NOT IN ('review_visibility_id') "
 			+ "ORDER BY ORDINAL_POSITION;",
 		nativeQuery = true
 	)

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/repository/ReviewVisibilityRepository.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/repository/ReviewVisibilityRepository.java
@@ -1,9 +1,21 @@
 package com.romanticpipe.reviewcanvas.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.romanticpipe.reviewcanvas.domain.ReviewVisibility;
 
 public interface ReviewVisibilityRepository extends JpaRepository<ReviewVisibility, Long> {
-
+	@Query(
+		value = "SELECT COLUMN_NAME\n"
+			+ "FROM INFORMATION_SCHEMA.COLUMNS\n"
+			+ "WHERE TABLE_SCHEMA = 'review_canvas_db'\n"
+			+ "  AND TABLE_NAME = 'review_visibility'\n"
+			+ "  AND COLUMN_NAME NOT IN ('review_visibility_id')\n"
+			+ "ORDER BY ORDINAL_POSITION;",
+		nativeQuery = true
+	)
+	List<String> getReviewVisibilityTitles();
 }

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/service/ReviewVisibilityReader.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/service/ReviewVisibilityReader.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class ShopAdminReader {
+public class ReviewVisibilityReader {
 	private final ReviewVisibilityRepository reviewVisibilityRepository;
 
 	public List<String> getReviewVisibilityTitle() {

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/service/ShopAdminReader.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/service/ShopAdminReader.java
@@ -14,7 +14,6 @@ public class ShopAdminReader {
 	private final ReviewVisibilityRepository reviewVisibilityRepository;
 
 	public List<String> getReviewVisibilityTitle() {
-
-		return null;
+		return reviewVisibilityRepository.getReviewVisibilityTitles();
 	}
 }

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/service/ShopAdminReader.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/service/ShopAdminReader.java
@@ -1,0 +1,20 @@
+package com.romanticpipe.reviewcanvas.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.romanticpipe.reviewcanvas.repository.ReviewVisibilityRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ShopAdminReader {
+	private final ReviewVisibilityRepository reviewVisibilityRepository;
+
+	public List<String> getReviewVisibilityTitle() {
+
+		return null;
+	}
+}


### PR DESCRIPTION
### 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

> 리뷰 노출 항목의 title을 조회하는 api를 구현합니다.

### ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

> shop admin에 getReviewVisibilityTitle api가 추가되었고 shopAdminReader가 추가되었습니다.

### 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?

> ReviewVisibilityRepository에 Query문을 사용하였습니다.

### 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요

> 없습니다.

### 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?

> 없습니다.
