### PR TITLE
인증 프로세스 API 수정 및 Cafe24 api token 재발급 자동화

### DIFF
--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/common/config/TransactionTemplateConfig.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/common/config/TransactionTemplateConfig.java
@@ -1,0 +1,24 @@
+package com.romanticpipe.reviewcanvas.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Configuration
+public class TransactionTemplateConfig {
+
+	@Bean
+	public TransactionTemplate writeTransactionTemplate(PlatformTransactionManager transactionManager) {
+		TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+		transactionTemplate.setReadOnly(false);
+		return transactionTemplate;
+	}
+
+	@Bean
+	public TransactionTemplate readTransactionTemplate(PlatformTransactionManager transactionManager) {
+		TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+		transactionTemplate.setReadOnly(true);
+		return transactionTemplate;
+	}
+}

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCase.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCase.java
@@ -2,7 +2,7 @@ package com.romanticpipe.reviewcanvas.domain.shop.application.usecase;
 
 import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.response.GetCafe24AccessTokenResponse;
 
-public interface ShopUseCase {
+public interface Cafe24UseCase {
 	GetCafe24AccessTokenResponse getCafe24AccessToken(String mallId, String authCode);
 
 	/**

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCase.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCase.java
@@ -1,7 +1,5 @@
 package com.romanticpipe.reviewcanvas.domain.shop.application.usecase;
 
-import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.response.GetCafe24AccessTokenResponse;
-
 public interface Cafe24UseCase {
-	GetCafe24AccessTokenResponse getCafe24AccessToken(String mallId, String authCode);
+	void cafe24AuthenticationProcess(String mallId, String authCode);
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCase.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCase.java
@@ -4,9 +4,4 @@ import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.response.Ge
 
 public interface Cafe24UseCase {
 	GetCafe24AccessTokenResponse getCafe24AccessToken(String mallId, String authCode);
-
-	/**
-	 * 만약 refresh token이 유효하지 않거나 만료되었을 경우, INVALID_OR_EXPIRED_REFRESH_TOKEN error를 발생시킨다.
-	 */
-	GetCafe24AccessTokenResponse reissueCafe24AccessToken(String mallId, String refreshToken);
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCaseImpl.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCaseImpl.java
@@ -1,15 +1,12 @@
 package com.romanticpipe.reviewcanvas.domain.shop.application.usecase;
 
-import com.romanticpipe.reviewcanvas.cafe24.Cafe24ErrorCode;
 import com.romanticpipe.reviewcanvas.cafe24.Cafe24FormUrlencodedFactory;
 import com.romanticpipe.reviewcanvas.cafe24.authentication.Cafe24AccessToken;
 import com.romanticpipe.reviewcanvas.cafe24.authentication.Cafe24AuthenticationClient;
 import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.response.GetCafe24AccessTokenResponse;
-import com.romanticpipe.reviewcanvas.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.HttpClientErrorException;
 
 @Component
 @RequiredArgsConstructor
@@ -22,19 +19,5 @@ public class Cafe24UseCaseImpl implements Cafe24UseCase {
 		MultiValueMap<String, String> requestParam = Cafe24FormUrlencodedFactory.getCafe24AccessToken(authCode);
 		Cafe24AccessToken cafe24AccessToken = cafe24AuthenticationClient.getAccessToken(mallId, requestParam);
 		return GetCafe24AccessTokenResponse.from(cafe24AccessToken);
-	}
-
-	@Override
-	public GetCafe24AccessTokenResponse reissueCafe24AccessToken(String mallId, String refreshToken) {
-		MultiValueMap<String, String> requestParam = Cafe24FormUrlencodedFactory.reissueCafe24AccessToken(refreshToken);
-		try {
-			Cafe24AccessToken cafe24AccessToken = cafe24AuthenticationClient.reissueAccessToken(mallId, requestParam);
-			return GetCafe24AccessTokenResponse.from(cafe24AccessToken);
-		} catch (HttpClientErrorException ex) {
-			if (ex.getResponseBodyAsString().contains("\"error\":\"invalid_grant\"")) {
-				throw new BusinessException(Cafe24ErrorCode.INVALID_OR_EXPIRED_REFRESH_TOKEN);
-			}
-			throw ex;
-		}
 	}
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCaseImpl.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCaseImpl.java
@@ -3,22 +3,40 @@ package com.romanticpipe.reviewcanvas.domain.shop.application.usecase;
 import com.romanticpipe.reviewcanvas.cafe24.Cafe24FormUrlencodedFactory;
 import com.romanticpipe.reviewcanvas.cafe24.authentication.Cafe24AccessToken;
 import com.romanticpipe.reviewcanvas.cafe24.authentication.Cafe24AuthenticationClient;
-import com.romanticpipe.reviewcanvas.service.ShopAdminTokenCreator;
+import com.romanticpipe.reviewcanvas.domain.ShopAuthToken;
+import com.romanticpipe.reviewcanvas.service.ShopAuthTokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.MultiValueMap;
 
 @Component
 @RequiredArgsConstructor
 public class Cafe24UseCaseImpl implements Cafe24UseCase {
 
+	private final TransactionTemplate writeTransactionTemplate;
 	private final Cafe24AuthenticationClient cafe24AuthenticationClient;
-	private final ShopAdminTokenCreator shopAdminTokenCreator;
+	private final ShopAuthTokenService shopAuthTokenService;
 
 	@Override
 	public void cafe24AuthenticationProcess(String mallId, String authCode) {
 		MultiValueMap<String, String> requestParam = Cafe24FormUrlencodedFactory.getCafe24AccessToken(authCode);
 		Cafe24AccessToken cafe24AccessToken = cafe24AuthenticationClient.getAccessToken(mallId, requestParam);
-		shopAdminTokenCreator.save(cafe24AccessToken.toShopAuthToken());
+		writeTransactionTemplate.executeWithoutResult(transactionStatus -> {
+			try {
+				shopAuthTokenService.findByMallId(mallId)
+					.ifPresentOrElse(shopAuthToken -> updateShopAuthToken(cafe24AccessToken, shopAuthToken)
+						, () -> shopAuthTokenService.save(cafe24AccessToken.toShopAuthToken()));
+			} catch (RuntimeException e) {
+				transactionStatus.setRollbackOnly();
+				throw e;
+			}
+		});
+	}
+
+	private void updateShopAuthToken(Cafe24AccessToken cafe24AccessToken, ShopAuthToken shopAuthToken) {
+		String scope = String.join(",", cafe24AccessToken.scopes());
+		shopAuthToken.update(cafe24AccessToken.accessToken(), cafe24AccessToken.expiresAt(),
+			cafe24AccessToken.refreshToken(), cafe24AccessToken.refreshTokenExpiresAt(), scope);
 	}
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCaseImpl.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCaseImpl.java
@@ -3,7 +3,6 @@ package com.romanticpipe.reviewcanvas.domain.shop.application.usecase;
 import com.romanticpipe.reviewcanvas.cafe24.Cafe24FormUrlencodedFactory;
 import com.romanticpipe.reviewcanvas.cafe24.authentication.Cafe24AccessToken;
 import com.romanticpipe.reviewcanvas.cafe24.authentication.Cafe24AuthenticationClient;
-import com.romanticpipe.reviewcanvas.domain.ShopAuthToken;
 import com.romanticpipe.reviewcanvas.service.ShopAdminTokenCreator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -20,16 +19,6 @@ public class Cafe24UseCaseImpl implements Cafe24UseCase {
 	public void cafe24AuthenticationProcess(String mallId, String authCode) {
 		MultiValueMap<String, String> requestParam = Cafe24FormUrlencodedFactory.getCafe24AccessToken(authCode);
 		Cafe24AccessToken cafe24AccessToken = cafe24AuthenticationClient.getAccessToken(mallId, requestParam);
-
-		String scope = cafe24AccessToken.scopes().stream().reduce((a, b) -> a + "," + b).orElse("");
-		ShopAuthToken shopAuthToken = ShopAuthToken.builder()
-			.mallId(cafe24AccessToken.mallId())
-			.accessToken(cafe24AccessToken.accessToken())
-			.accessTokenExpiresAt(cafe24AccessToken.expiresAt())
-			.refreshToken(cafe24AccessToken.refreshToken())
-			.refreshTokenExpiresAt(cafe24AccessToken.refreshTokenExpiresAt())
-			.scope(scope)
-			.build();
-		shopAdminTokenCreator.save(shopAuthToken);
+		shopAdminTokenCreator.save(cafe24AccessToken.toShopAuthToken());
 	}
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCaseImpl.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCaseImpl.java
@@ -13,7 +13,7 @@ import org.springframework.web.client.HttpClientErrorException;
 
 @Component
 @RequiredArgsConstructor
-public class ShopUseCaseImpl implements ShopUseCase {
+public class Cafe24UseCaseImpl implements Cafe24UseCase {
 
 	private final Cafe24AuthenticationClient cafe24AuthenticationClient;
 

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCaseImpl.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCaseImpl.java
@@ -25,8 +25,8 @@ public class Cafe24UseCaseImpl implements Cafe24UseCase {
 		writeTransactionTemplate.executeWithoutResult(transactionStatus -> {
 			try {
 				shopAuthTokenService.findByMallId(mallId)
-					.ifPresentOrElse(shopAuthToken -> updateShopAuthToken(cafe24AccessToken, shopAuthToken)
-						, () -> shopAuthTokenService.save(cafe24AccessToken.toShopAuthToken()));
+					.ifPresentOrElse(shopAuthToken -> updateShopAuthToken(cafe24AccessToken, shopAuthToken),
+						() -> shopAuthTokenService.save(cafe24AccessToken.toShopAuthToken()));
 			} catch (RuntimeException e) {
 				transactionStatus.setRollbackOnly();
 				throw e;

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@Tag(name = "shop", description = "쇼핑몰 API")
+@Tag(name = "cafe24", description = "Cafe24 쇼핑몰 API")
 @SecurityRequirement(name = "Bearer Authentication")
 public interface Cafe24Api {
 
@@ -22,7 +22,7 @@ public interface Cafe24Api {
 	@ApiResponses(value = {
 		@ApiResponse(
 			responseCode = "200",
-			description = "성공적으로 액세스 토큰을 발급했습니다."),
+			description = "성공적으로 인증 프로세스를 수행했습니다."),
 		@ApiResponse(
 			responseCode = "400",
 			description = "C003: 외부 API 호출 중 오류가 발생했습니다.",

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "shop", description = "쇼핑몰 API")
 @SecurityRequirement(name = "Bearer Authentication")
-public interface ShopApi {
+public interface Cafe24Api {
 
 	@Operation(summary = "cafe24 액세스 토큰 발급", description = "auth code로 cafe24 액세스 토큰을 발급한다. "
 		+ "https://developers.cafe24.com/app/front/app/develop/oauth/token")

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
@@ -9,7 +9,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "shop", description = "쇼핑몰 API")
@@ -27,9 +28,9 @@ public interface Cafe24Api {
 			description = "C003: 외부 API 호출 중 오류가 발생했습니다.",
 			content = @Content(schema = @Schema(hidden = true))),
 	})
-	@GetMapping("/cafe24/authentication-process")
+	@PostMapping("/cafe24/{mallId}/authentication-process")
 	ResponseEntity<SuccessResponse<Void>> cafe24AuthenticationProcess(
-		@Schema(name = "mall id", description = "쇼핑몰의 아이디") @RequestParam(required = true) String mallId,
+		@Schema(name = "mall id", description = "쇼핑몰의 아이디") @PathVariable(required = true) String mallId,
 		@Schema(name = "authorization code", description = "인증 코드") @RequestParam(required = true) String authCode
 	);
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
@@ -1,7 +1,6 @@
 package com.romanticpipe.reviewcanvas.domain.shop.presentation.v1;
 
 import com.romanticpipe.reviewcanvas.common.dto.SuccessResponse;
-import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.response.GetCafe24AccessTokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -17,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @SecurityRequirement(name = "Bearer Authentication")
 public interface Cafe24Api {
 
-	@Operation(summary = "cafe24 액세스 토큰 발급", description = "auth code로 cafe24 액세스 토큰을 발급한다. "
+	@Operation(summary = "cafe24 인증 프로세스 api", description = "auth code로 cafe24 액세스 토큰을 발급받아 서버에 저장한다 "
 		+ "https://developers.cafe24.com/app/front/app/develop/oauth/token")
 	@ApiResponses(value = {
 		@ApiResponse(
@@ -28,8 +27,8 @@ public interface Cafe24Api {
 			description = "C003: 외부 API 호출 중 오류가 발생했습니다.",
 			content = @Content(schema = @Schema(hidden = true))),
 	})
-	@GetMapping("/cafe24/access-token")
-	ResponseEntity<SuccessResponse<GetCafe24AccessTokenResponse>> getCafe24AccessToken(
+	@GetMapping("/cafe24/authentication-process")
+	ResponseEntity<SuccessResponse<Void>> cafe24AuthenticationProcess(
 		@Schema(name = "mall id", description = "쇼핑몰의 아이디") @RequestParam(required = true) String mallId,
 		@Schema(name = "authorization code", description = "인증 코드") @RequestParam(required = true) String authCode
 	);

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
@@ -33,23 +33,4 @@ public interface Cafe24Api {
 		@Schema(name = "mall id", description = "쇼핑몰의 아이디") @RequestParam(required = true) String mallId,
 		@Schema(name = "authorization code", description = "인증 코드") @RequestParam(required = true) String authCode
 	);
-
-	@Operation(summary = "cafe24 액세스 토큰 재발급", description = "refresh token으로 cafe24 access token을 재발급한다. "
-		+ "[주의]: 해당 api를 호출하면 refresh token도 항상 재발급됩니다. "
-		+ "https://developers.cafe24.com/app/front/app/develop/oauth/retoken")
-	@ApiResponses(value = {
-		@ApiResponse(
-			responseCode = "200",
-			description = "성공적으로 액세스 토큰을 재발급했습니다."),
-		@ApiResponse(
-			responseCode = "400",
-			description = "C003: 외부 API 호출 중 오류가 발생했습니다.",
-			content = @Content(schema = @Schema(hidden = true))),
-	})
-	@GetMapping("/cafe24/reissue-access-token")
-	ResponseEntity<SuccessResponse<GetCafe24AccessTokenResponse>> reissueCafe24AccessToken(
-		@Schema(name = "mall id", description = "쇼핑몰의 아이디") @RequestParam(required = true) String mallId,
-		@Schema(name = "refresh token", description = "cafe24 refresh token")
-		@RequestParam(required = true) String refreshToken
-	);
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Controller.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Controller.java
@@ -28,14 +28,4 @@ public class Cafe24Controller implements Cafe24Api {
 		GetCafe24AccessTokenResponse response = cafe24UseCase.getCafe24AccessToken(mallId, authCode);
 		return SuccessResponse.of(response).asHttp(HttpStatus.OK);
 	}
-
-	@Override
-	@GetMapping("/cafe24/reissue-access-token")
-	public ResponseEntity<SuccessResponse<GetCafe24AccessTokenResponse>> reissueCafe24AccessToken(
-		@RequestParam(required = true) String mallId,
-		@RequestParam(required = true) String refreshToken
-	) {
-		GetCafe24AccessTokenResponse response = cafe24UseCase.reissueCafe24AccessToken(mallId, refreshToken);
-		return SuccessResponse.of(response).asHttp(HttpStatus.OK);
-	}
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Controller.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Controller.java
@@ -2,7 +2,6 @@ package com.romanticpipe.reviewcanvas.domain.shop.presentation.v1;
 
 import com.romanticpipe.reviewcanvas.common.dto.SuccessResponse;
 import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.Cafe24UseCase;
-import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.response.GetCafe24AccessTokenResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,12 +19,12 @@ public class Cafe24Controller implements Cafe24Api {
 	private final Cafe24UseCase cafe24UseCase;
 
 	@Override
-	@GetMapping("/cafe24/access-token")
-	public ResponseEntity<SuccessResponse<GetCafe24AccessTokenResponse>> getCafe24AccessToken(
+	@GetMapping("/cafe24/authentication-process")
+	public ResponseEntity<SuccessResponse<Void>> cafe24AuthenticationProcess(
 		@RequestParam(required = true) String mallId,
 		@RequestParam(required = true) String authCode
 	) {
-		GetCafe24AccessTokenResponse response = cafe24UseCase.getCafe24AccessToken(mallId, authCode);
-		return SuccessResponse.of(response).asHttp(HttpStatus.OK);
+		cafe24UseCase.cafe24AuthenticationProcess(mallId, authCode);
+		return SuccessResponse.ofNoData().asHttp(HttpStatus.OK);
 	}
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Controller.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Controller.java
@@ -1,7 +1,7 @@
 package com.romanticpipe.reviewcanvas.domain.shop.presentation.v1;
 
 import com.romanticpipe.reviewcanvas.common.dto.SuccessResponse;
-import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.ShopUseCase;
+import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.Cafe24UseCase;
 import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.response.GetCafe24AccessTokenResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,9 +15,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
-public class ShopController implements ShopApi {
+public class Cafe24Controller implements Cafe24Api {
 
-	private final ShopUseCase shopUseCase;
+	private final Cafe24UseCase cafe24UseCase;
 
 	@Override
 	@GetMapping("/cafe24/access-token")
@@ -25,7 +25,7 @@ public class ShopController implements ShopApi {
 		@RequestParam(required = true) String mallId,
 		@RequestParam(required = true) String authCode
 	) {
-		GetCafe24AccessTokenResponse response = shopUseCase.getCafe24AccessToken(mallId, authCode);
+		GetCafe24AccessTokenResponse response = cafe24UseCase.getCafe24AccessToken(mallId, authCode);
 		return SuccessResponse.of(response).asHttp(HttpStatus.OK);
 	}
 
@@ -35,7 +35,7 @@ public class ShopController implements ShopApi {
 		@RequestParam(required = true) String mallId,
 		@RequestParam(required = true) String refreshToken
 	) {
-		GetCafe24AccessTokenResponse response = shopUseCase.reissueCafe24AccessToken(mallId, refreshToken);
+		GetCafe24AccessTokenResponse response = cafe24UseCase.reissueCafe24AccessToken(mallId, refreshToken);
 		return SuccessResponse.of(response).asHttp(HttpStatus.OK);
 	}
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Controller.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Controller.java
@@ -5,7 +5,8 @@ import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.Cafe24UseCa
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,9 +20,9 @@ public class Cafe24Controller implements Cafe24Api {
 	private final Cafe24UseCase cafe24UseCase;
 
 	@Override
-	@GetMapping("/cafe24/authentication-process")
+	@PostMapping("/cafe24/{mallId}/authentication-process")
 	public ResponseEntity<SuccessResponse<Void>> cafe24AuthenticationProcess(
-		@RequestParam(required = true) String mallId,
+		@PathVariable(required = true) String mallId,
 		@RequestParam(required = true) String authCode
 	) {
 		cafe24UseCase.cafe24AuthenticationProcess(mallId, authCode);

--- a/client-module/build.gradle
+++ b/client-module/build.gradle
@@ -1,5 +1,8 @@
 dependencies {
     implementation project(':common-module')
+    implementation project(':domain-module')
+    implementation project(':domain-module:review')
+    implementation project(':domain-module:shopadmin')
 
     implementation 'org.springframework:spring-context'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24ErrorCode.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24ErrorCode.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Cafe24ErrorCode implements ErrorCode {
 
-	INVALID_OR_EXPIRED_REFRESH_TOKEN(400, "CA001", "cafe24 refresh token이 유효하지 않거나 만료되었습니다.");
+	INVALID_OR_EXPIRED_REFRESH_TOKEN(400, "CA001", "cafe24 refresh token이 유효하지 않거나 만료되었습니다."),
+	PRODUCT_NOT_FOUND(400, "CA002", "CAFE24 상품을 찾을 수 없습니다.");
 
 	private final int status;
 	private final String code;

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24HttpExchangeConfig.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24HttpExchangeConfig.java
@@ -1,6 +1,7 @@
 package com.romanticpipe.reviewcanvas.cafe24;
 
 import com.romanticpipe.reviewcanvas.cafe24.authentication.Cafe24AuthenticationClient;
+import com.romanticpipe.reviewcanvas.cafe24.product.Cafe24ProductClient;
 import com.romanticpipe.reviewcanvas.config.RestClientLoggingInterceptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,5 +31,18 @@ class Cafe24HttpExchangeConfig {
 			.build();
 
 		return getHttpExchange(restClient, Cafe24AuthenticationClient.class);
+	}
+
+	@Bean
+	public Cafe24ProductClient cafe24ProductClient(
+		ClientHttpRequestFactory clientHttpRequestFactory, RestClientLoggingInterceptor restClientLoggingInterceptor,
+		Cafe24TokenInterceptor cafe24TokenInterceptor) {
+		RestClient restClient = RestClient.builder()
+			.requestFactory(clientHttpRequestFactory)
+			.requestInterceptor(restClientLoggingInterceptor)
+			.requestInterceptor(cafe24TokenInterceptor)
+			.build();
+
+		return getHttpExchange(restClient, Cafe24ProductClient.class);
 	}
 }

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24TokenInterceptor.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24TokenInterceptor.java
@@ -24,7 +24,8 @@ public class Cafe24TokenInterceptor implements ClientHttpRequestInterceptor {
 	private final Cafe24AuthenticationClient cafe24AuthenticationClient;
 
 	@Override
-	public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+	public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
+		throws IOException {
 		String mallId = extractMallId(request);
 		ShopAuthToken shopAuthToken = shopAuthTokenService.validateByMallId(mallId);
 		reissueAccessTokenIfNeeded(shopAuthToken, mallId);

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24TokenInterceptor.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24TokenInterceptor.java
@@ -6,6 +6,7 @@ import com.romanticpipe.reviewcanvas.domain.ShopAuthToken;
 import com.romanticpipe.reviewcanvas.exception.BusinessException;
 import com.romanticpipe.reviewcanvas.service.ShopAuthTokenService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
@@ -16,6 +17,7 @@ import org.springframework.util.StringUtils;
 import java.io.IOException;
 import java.time.LocalDateTime;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class Cafe24TokenInterceptor implements ClientHttpRequestInterceptor {
@@ -45,11 +47,13 @@ public class Cafe24TokenInterceptor implements ClientHttpRequestInterceptor {
 	private void reissueAccessTokenIfNeeded(ShopAuthToken shopAuthToken, String mallId) {
 		LocalDateTime now = LocalDateTime.now();
 		if (now.isAfter(shopAuthToken.getRefreshTokenExpiresAt())) {
+			log.warn("Cafe24 refresh token이 만료되었습니다. [mallId: {}]", mallId);
 			throw new BusinessException(Cafe24ErrorCode.INVALID_OR_EXPIRED_REFRESH_TOKEN);
 		}
 		if (now.isAfter(shopAuthToken.getAccessTokenExpiresAt())) {
 			Cafe24AccessToken newToken = reissueAccessToken(shopAuthToken, mallId);
 			updateShopAuthToken(shopAuthToken, newToken);
+			log.info("Cafe24 access token을 재발급하여 db에 저장했습니다. [mallId: {}]", mallId);
 		}
 	}
 

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24TokenInterceptor.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24TokenInterceptor.java
@@ -1,0 +1,65 @@
+package com.romanticpipe.reviewcanvas.cafe24;
+
+import com.romanticpipe.reviewcanvas.cafe24.authentication.Cafe24AccessToken;
+import com.romanticpipe.reviewcanvas.cafe24.authentication.Cafe24AuthenticationClient;
+import com.romanticpipe.reviewcanvas.domain.ShopAuthToken;
+import com.romanticpipe.reviewcanvas.exception.BusinessException;
+import com.romanticpipe.reviewcanvas.service.ShopAuthTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class Cafe24TokenInterceptor implements ClientHttpRequestInterceptor {
+
+	private final ShopAuthTokenService shopAuthTokenService;
+	private final Cafe24AuthenticationClient cafe24AuthenticationClient;
+
+	@Override
+	public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+		String mallId = extractMallId(request);
+		ShopAuthToken shopAuthToken = shopAuthTokenService.validateByMallId(mallId);
+		reissueAccessTokenIfNeeded(shopAuthToken, mallId);
+
+		request.getHeaders().add("Authorization", "Bearer " + shopAuthToken.getAccessToken());
+		return execution.execute(request, body);
+	}
+
+	private String extractMallId(HttpRequest request) {
+		String mallId = request.getURI().getHost().split("\\.")[0];
+		if (StringUtils.hasText(mallId)) {
+			return mallId;
+		}
+		throw new IllegalArgumentException("cafe24 api 호출 시 mallId는 필수입니다.");
+	}
+
+	private void reissueAccessTokenIfNeeded(ShopAuthToken shopAuthToken, String mallId) {
+		LocalDateTime now = LocalDateTime.now();
+		if (now.isAfter(shopAuthToken.getRefreshTokenExpiresAt())) {
+			throw new BusinessException(Cafe24ErrorCode.INVALID_OR_EXPIRED_REFRESH_TOKEN);
+		}
+		if (now.isAfter(shopAuthToken.getAccessTokenExpiresAt())) {
+			Cafe24AccessToken newToken = reissueAccessToken(shopAuthToken, mallId);
+			updateShopAuthToken(shopAuthToken, newToken);
+		}
+	}
+
+	private Cafe24AccessToken reissueAccessToken(ShopAuthToken shopAuthToken, String mallId) {
+		return cafe24AuthenticationClient.reissueAccessToken(mallId,
+			Cafe24FormUrlencodedFactory.reissueCafe24AccessToken(shopAuthToken.getRefreshToken()));
+	}
+
+	private void updateShopAuthToken(ShopAuthToken shopAuthToken, Cafe24AccessToken newToken) {
+		shopAuthToken.update(newToken.accessToken(), newToken.expiresAt(), newToken.refreshToken(),
+			newToken.refreshTokenExpiresAt(), String.join(",", newToken.scopes()));
+		shopAuthTokenService.save(shopAuthToken);
+	}
+}

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/authentication/Cafe24AccessToken.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/authentication/Cafe24AccessToken.java
@@ -19,7 +19,7 @@ public record Cafe24AccessToken(String accessToken,
 								LocalDateTime issuedAt) {
 
 	public ShopAuthToken toShopAuthToken() {
-		String scope = scopes.stream().reduce((a, b) -> a + "," + b).orElse("");
+		String scope = String.join(",", scopes);
 		return ShopAuthToken.builder()
 			.mallId(mallId)
 			.accessToken(accessToken)

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/authentication/Cafe24AccessToken.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/authentication/Cafe24AccessToken.java
@@ -2,6 +2,7 @@ package com.romanticpipe.reviewcanvas.cafe24.authentication;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.romanticpipe.reviewcanvas.domain.ShopAuthToken;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,4 +17,16 @@ public record Cafe24AccessToken(String accessToken,
 								String userId,
 								List<String> scopes,
 								LocalDateTime issuedAt) {
+
+	public ShopAuthToken toShopAuthToken() {
+		String scope = scopes.stream().reduce((a, b) -> a + "," + b).orElse("");
+		return ShopAuthToken.builder()
+			.mallId(mallId)
+			.accessToken(accessToken)
+			.accessTokenExpiresAt(expiresAt)
+			.refreshToken(refreshToken)
+			.refreshTokenExpiresAt(refreshTokenExpiresAt)
+			.scope(scope)
+			.build();
+	}
 }

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/product/Cafe24Product.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/product/Cafe24Product.java
@@ -1,4 +1,30 @@
 package com.romanticpipe.reviewcanvas.cafe24.product;
 
-public record Cafe24Product() {
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+public class Cafe24Product {
+	private final Product product;
+
+	@JsonCreator
+	public Cafe24Product(Product product) {
+		this.product = product;
+	}
+
+	public Long getProductNo() {
+		return product.productNo();
+	}
+
+	public String getProductName() {
+		return product.productName();
+	}
+
+	public void validateCafe24Product(String mallId, Long productNo) {
+		if (!StringUtils.hasText(getProductName())) {
+			log.info("Cafe24로부터 [mallId: {}] [productNo: {}]에 해당하는 상품을 가져올 수 없습니다.", mallId, productNo);
+			throw new Cafe24ProductNotFoundException();
+		}
+	}
 }

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/product/Cafe24Product.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/product/Cafe24Product.java
@@ -1,0 +1,4 @@
+package com.romanticpipe.reviewcanvas.cafe24.product;
+
+public record Cafe24Product() {
+}

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/product/Cafe24ProductClient.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/product/Cafe24ProductClient.java
@@ -5,12 +5,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
 
-import java.util.Map;
-
 @Component
 @HttpExchange("https://{mallId}.cafe24api.com/api/v2")
 public interface Cafe24ProductClient {
 
 	@GetExchange(value = "/admin/products/{productNo}")
-	Map<String, Object> getProduct(@PathVariable String mallId, @PathVariable Long productNo);
+	Cafe24Product getProduct(@PathVariable String mallId, @PathVariable Long productNo);
 }

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/product/Cafe24ProductClient.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/product/Cafe24ProductClient.java
@@ -1,0 +1,16 @@
+package com.romanticpipe.reviewcanvas.cafe24.product;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+
+import java.util.Map;
+
+@Component
+@HttpExchange("https://{mallId}.cafe24api.com/api/v2")
+public interface Cafe24ProductClient {
+
+	@GetExchange(value = "/admin/products/{productNo}")
+	Map<String, Object> getProduct(@PathVariable String mallId, @PathVariable Long productNo);
+}

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/product/Cafe24ProductNotFoundException.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/product/Cafe24ProductNotFoundException.java
@@ -1,0 +1,10 @@
+package com.romanticpipe.reviewcanvas.cafe24.product;
+
+import com.romanticpipe.reviewcanvas.cafe24.Cafe24ErrorCode;
+import com.romanticpipe.reviewcanvas.exception.BusinessException;
+
+public class Cafe24ProductNotFoundException extends BusinessException {
+	public Cafe24ProductNotFoundException() {
+		super(Cafe24ErrorCode.PRODUCT_NOT_FOUND);
+	}
+}

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/product/Product.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/product/Product.java
@@ -1,0 +1,10 @@
+package com.romanticpipe.reviewcanvas.cafe24.product;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+record Product(Long productNo, String productName) {
+}

--- a/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/exception/ProductNofFoundException.java
+++ b/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/exception/ProductNofFoundException.java
@@ -1,0 +1,7 @@
+package com.romanticpipe.reviewcanvas.exception;
+
+public class ProductNofFoundException extends BusinessException {
+	public ProductNofFoundException() {
+		super(ReviewErrorCode.PRODUCT_NOT_FOUND);
+	}
+}

--- a/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/exception/ReviewErrorCode.java
+++ b/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/exception/ReviewErrorCode.java
@@ -4,7 +4,12 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum ReviewErrorCode implements ErrorCode {
-	REVIEW_NOT_FOUND(400, "R001", "리뷰를 찾을 수 없습니다.");
+
+	// Review
+	REVIEW_NOT_FOUND(400, "R001", "리뷰를 찾을 수 없습니다."),
+
+	// Product
+	PRODUCT_NOT_FOUND(400, "R002", "상품을 찾을 수 없습니다.");
 
 	private final int status;
 	private final String code;

--- a/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/repository/ProductRepository.java
+++ b/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/repository/ProductRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, String> {
 
-	@Query("SELECT p FROM Product p JOIN ShopAdmin s ON p.shopAdminId = s.id " +
-		"WHERE s.mallId = :mallId AND p.productNo = :productNo")
+	@Query("SELECT p FROM Product p JOIN ShopAdmin s ON p.shopAdminId = s.id "
+		+ "WHERE s.mallId = :mallId AND p.productNo = :productNo")
 	Optional<Product> findByMallIdAndProductNo(String mallId, Long productNo);
 }

--- a/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/repository/ProductRepository.java
+++ b/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/repository/ProductRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, String> {
 
-	@Query("SELECT p FROM Product p JOIN ShopAdmin s WHERE s.mallId = :mallId AND p.productNo = :productNo")
+	@Query("SELECT p FROM Product p JOIN ShopAdmin s ON p.shopAdminId = s.id " +
+		"WHERE s.mallId = :mallId AND p.productNo = :productNo")
 	Optional<Product> findByMallIdAndProductNo(String mallId, Long productNo);
 }

--- a/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/service/ProductCreator.java
+++ b/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/service/ProductCreator.java
@@ -1,0 +1,17 @@
+package com.romanticpipe.reviewcanvas.service;
+
+import com.romanticpipe.reviewcanvas.domain.Product;
+import com.romanticpipe.reviewcanvas.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductCreator {
+
+	private final ProductRepository productRepository;
+
+	public Product save(Product product) {
+		return productRepository.save(product);
+	}
+}

--- a/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/service/ProductValidator.java
+++ b/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/service/ProductValidator.java
@@ -3,6 +3,7 @@ package com.romanticpipe.reviewcanvas.service;
 import com.romanticpipe.reviewcanvas.domain.Product;
 import com.romanticpipe.reviewcanvas.exception.BusinessException;
 import com.romanticpipe.reviewcanvas.exception.ProductErrorCode;
+import com.romanticpipe.reviewcanvas.exception.ProductNofFoundException;
 import com.romanticpipe.reviewcanvas.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,4 +19,8 @@ public class ProductValidator {
 			.orElseThrow(() -> new BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND));
 	}
 
+	public Product validateByMallIdAndProductNo(String mallId, Long productNo) {
+		return productRepository.findByMallIdAndProductNo(mallId, productNo)
+			.orElseThrow(ProductNofFoundException::new);
+	}
 }

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/domain/ShopAuthToken.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/domain/ShopAuthToken.java
@@ -39,4 +39,13 @@ public class ShopAuthToken extends BaseEntity {
 		this.refreshTokenExpiresAt = refreshTokenExpiresAt;
 		this.scope = scope;
 	}
+
+	public void update(String accessToken, LocalDateTime accessTokenExpiresAt, String refreshToken,
+					   LocalDateTime refreshTokenExpiresAt, String scope) {
+		this.accessToken = accessToken;
+		this.accessTokenExpiresAt = accessTokenExpiresAt;
+		this.refreshToken = refreshToken;
+		this.refreshTokenExpiresAt = refreshTokenExpiresAt;
+		this.scope = scope;
+	}
 }

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/domain/ShopAuthToken.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/domain/ShopAuthToken.java
@@ -1,0 +1,42 @@
+package com.romanticpipe.reviewcanvas.domain;
+
+import com.romanticpipe.reviewcanvas.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class ShopAuthToken extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "shop_auth_token_id")
+	private Integer id;
+
+	private String mallId;
+	private String accessToken;
+	private LocalDateTime accessTokenExpiresAt;
+	private String refreshToken;
+	private LocalDateTime refreshTokenExpiresAt;
+	private String scope;
+
+	@Builder
+	public ShopAuthToken(String mallId, String accessToken, LocalDateTime accessTokenExpiresAt, String refreshToken,
+						 LocalDateTime refreshTokenExpiresAt, String scope) {
+		this.mallId = mallId;
+		this.accessToken = accessToken;
+		this.accessTokenExpiresAt = accessTokenExpiresAt;
+		this.refreshToken = refreshToken;
+		this.refreshTokenExpiresAt = refreshTokenExpiresAt;
+		this.scope = scope;
+	}
+}

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/exception/ShopAdminErrorCode.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/exception/ShopAdminErrorCode.java
@@ -13,7 +13,10 @@ public enum ShopAdminErrorCode implements ErrorCode {
 	ADMIN_WRONG_PASSWORD(400, "A002", "비밀번호가 잘못 입력되었습니다."),
 
 	// AdminAuth
-	ADMIN_AUTH_NOT_FOUND(400, "AA001", "refresh token을 찾을 수 없습니다.");
+	ADMIN_AUTH_NOT_FOUND(400, "AA001", "refresh token을 찾을 수 없습니다."),
+
+	// ShopAuthToken
+	SHOP_AUTH_TOKEN_NOT_FOUND(400, "SAT001", "ShopAuthToken을 찾을 수 없습니다.");
 
 	private final int status;
 	private final String code;

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/exception/ShopAuthTokenNotFoundException.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/exception/ShopAuthTokenNotFoundException.java
@@ -1,0 +1,7 @@
+package com.romanticpipe.reviewcanvas.exception;
+
+public class ShopAuthTokenNotFoundException extends BusinessException {
+	public ShopAuthTokenNotFoundException() {
+		super(ShopAdminErrorCode.SHOP_AUTH_TOKEN_NOT_FOUND);
+	}
+}

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/repository/ShopAdminRepository.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/repository/ShopAdminRepository.java
@@ -9,4 +9,6 @@ public interface ShopAdminRepository extends JpaRepository<ShopAdmin, Integer> {
 	Optional<ShopAdmin> findByEmail(String email);
 
 	boolean existsByEmail(String email);
+
+	Optional<ShopAdmin> findByMallId(String mallId);
 }

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/repository/ShopAdminTokenRepository.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/repository/ShopAdminTokenRepository.java
@@ -1,0 +1,7 @@
+package com.romanticpipe.reviewcanvas.repository;
+
+import com.romanticpipe.reviewcanvas.domain.ShopAuthToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShopAdminTokenRepository extends JpaRepository<ShopAuthToken, Integer> {
+}

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/repository/ShopAuthTokenRepository.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/repository/ShopAuthTokenRepository.java
@@ -3,5 +3,5 @@ package com.romanticpipe.reviewcanvas.repository;
 import com.romanticpipe.reviewcanvas.domain.ShopAuthToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ShopAdminTokenRepository extends JpaRepository<ShopAuthToken, Integer> {
+public interface ShopAuthTokenRepository extends JpaRepository<ShopAuthToken, Integer> {
 }

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/repository/ShopAuthTokenRepository.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/repository/ShopAuthTokenRepository.java
@@ -3,5 +3,8 @@ package com.romanticpipe.reviewcanvas.repository;
 import com.romanticpipe.reviewcanvas.domain.ShopAuthToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ShopAuthTokenRepository extends JpaRepository<ShopAuthToken, Integer> {
+	Optional<ShopAuthToken> findByMallId(String mallId);
 }

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/service/ShopAdminTokenCreator.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/service/ShopAdminTokenCreator.java
@@ -1,0 +1,17 @@
+package com.romanticpipe.reviewcanvas.service;
+
+import com.romanticpipe.reviewcanvas.domain.ShopAuthToken;
+import com.romanticpipe.reviewcanvas.repository.ShopAdminTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ShopAdminTokenCreator {
+
+	private final ShopAdminTokenRepository shopAdminTokenRepository;
+
+	public ShopAuthToken save(ShopAuthToken shopAuthToken) {
+		return shopAdminTokenRepository.save(shopAuthToken);
+	}
+}

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/service/ShopAdminTokenCreator.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/service/ShopAdminTokenCreator.java
@@ -1,7 +1,7 @@
 package com.romanticpipe.reviewcanvas.service;
 
 import com.romanticpipe.reviewcanvas.domain.ShopAuthToken;
-import com.romanticpipe.reviewcanvas.repository.ShopAdminTokenRepository;
+import com.romanticpipe.reviewcanvas.repository.ShopAuthTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,9 +9,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ShopAdminTokenCreator {
 
-	private final ShopAdminTokenRepository shopAdminTokenRepository;
+	private final ShopAuthTokenRepository shopAuthTokenRepository;
 
 	public ShopAuthToken save(ShopAuthToken shopAuthToken) {
-		return shopAdminTokenRepository.save(shopAuthToken);
+		return shopAuthTokenRepository.save(shopAuthToken);
 	}
 }

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/service/ShopAdminValidator.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/service/ShopAdminValidator.java
@@ -39,4 +39,9 @@ public class ShopAdminValidator {
 	public boolean isExistEmail(String email) {
 		return shopAdminRepository.existsByEmail(email);
 	}
+
+	public ShopAdmin validByMallId(String mallId) {
+		return shopAdminRepository.findByMallId(mallId)
+			.orElseThrow(AdminNotFoundException::new);
+	}
 }

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/service/ShopAuthTokenService.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/service/ShopAuthTokenService.java
@@ -1,17 +1,29 @@
 package com.romanticpipe.reviewcanvas.service;
 
 import com.romanticpipe.reviewcanvas.domain.ShopAuthToken;
+import com.romanticpipe.reviewcanvas.exception.ShopAuthTokenNotFoundException;
 import com.romanticpipe.reviewcanvas.repository.ShopAuthTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
-public class ShopAdminTokenCreator {
+public class ShopAuthTokenService {
 
 	private final ShopAuthTokenRepository shopAuthTokenRepository;
 
 	public ShopAuthToken save(ShopAuthToken shopAuthToken) {
 		return shopAuthTokenRepository.save(shopAuthToken);
+	}
+
+	public ShopAuthToken validateByMallId(String mallId) {
+		return shopAuthTokenRepository.findByMallId(mallId)
+			.orElseThrow(ShopAuthTokenNotFoundException::new);
+	}
+
+	public Optional<ShopAuthToken> findByMallId(String mallId) {
+		return shopAuthTokenRepository.findByMallId(mallId);
 	}
 }


### PR DESCRIPTION
### 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

- 인증 프로세스 단계에서 필요한 api가 잘못된 방식으로 구현되어 있습니다(cafe24 access token 및 refresh token을 프론트에게 반환하고 있었음). 이를 해결하고자 token을 서버에 저장하는 방식으로 변경했습니다.
- cafe24 api를 호출할 때 access token이 만료된 경우 refresh token을 재발급받고, db에 저장한 다음 새로운 access token으로 다시 요청해야 하는 번거로움이 있어 자동화할 필요가 있어 보입니다.

### ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

- 인증 api(/cafe24/{mallId}/authentication-process) 생성
- cafe24 get access token, reissue access token api 삭제
- Cafe24TokenInterceptor 생성

### 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?

- shop_auth_token 테이블이 추가되었습니다.
- TransactionTemplate 빈을 등록하여 명시적 트랜잭션을 가능하도록 구성했습니다.
- client 모듈이 domain 모듈을 의존 가능하도록 변경했습니다.

### 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요

DDL v0.1.0에 shop_auth_token 테이블을 생성했습니다.

### 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?

현재 구조는 cafe24 api를 호출할 때 항상 db에서 access token을 조회하여 헤더에 넣습니다. 만약 배치 작업이나 스케줄링 작업을 수행하게 될 경우 현 구조는 비효율적이므로 자료구조를 통해 애플리케이션에 저장하는 방식으로 변경해야 할 것입니다.
