### PR TITLE
hotfix: cafe24 인증 프로세스 api 접근을 위한 토큰 인증을 삭제합니다.

### DIFF
--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/common/security/AccessPath.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/common/security/AccessPath.java
@@ -34,6 +34,9 @@ public final class AccessPath {
 		// health check
 		allAllowedPath.put("/api/v1/health", allMethod);
 
+		// cafe24
+		allAllowedPath.put("/api/v1/cafe24/{mallId}/authentication-process", List.of(HttpMethod.POST));
+
 		// auth
 		allAllowedPath.put("/api/v1/shop-admin/login", List.of(HttpMethod.POST));
 		allAllowedPath.put("/api/v1/super-admin/login", List.of(HttpMethod.POST));

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,7 +13,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "cafe24", description = "Cafe24 쇼핑몰 API")
-@SecurityRequirement(name = "Bearer Authentication")
 public interface Cafe24Api {
 
 	@Operation(summary = "cafe24 인증 프로세스 api", description = "auth code로 cafe24 액세스 토큰을 발급받아 서버에 저장한다 "


### PR DESCRIPTION
cafe24 인증 프로세스 api를 토큰 인증 없이 사용 가능하도록 변경합니다.