### PR TITLE
cafe24 create script tag api를 생성한다

### DIFF
--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCase.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCase.java
@@ -1,5 +1,9 @@
 package com.romanticpipe.reviewcanvas.domain.shop.application.usecase;
 
+import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.request.Cafe24CreateScriptTagRequest;
+
 public interface Cafe24UseCase {
 	void cafe24AuthenticationProcess(String mallId, String authCode);
+
+	String cafe24CreateScriptTag(String mallId, Cafe24CreateScriptTagRequest request);
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCaseImpl.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCaseImpl.java
@@ -1,9 +1,11 @@
 package com.romanticpipe.reviewcanvas.domain.shop.application.usecase;
 
 import com.romanticpipe.reviewcanvas.cafe24.Cafe24FormUrlencodedFactory;
+import com.romanticpipe.reviewcanvas.cafe24.application.Cafe24ApplicationClient;
 import com.romanticpipe.reviewcanvas.cafe24.authentication.Cafe24AccessToken;
 import com.romanticpipe.reviewcanvas.cafe24.authentication.Cafe24AuthenticationClient;
 import com.romanticpipe.reviewcanvas.domain.ShopAuthToken;
+import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.request.Cafe24CreateScriptTagRequest;
 import com.romanticpipe.reviewcanvas.service.ShopAuthTokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -16,6 +18,7 @@ public class Cafe24UseCaseImpl implements Cafe24UseCase {
 
 	private final TransactionTemplate writeTransactionTemplate;
 	private final Cafe24AuthenticationClient cafe24AuthenticationClient;
+	private final Cafe24ApplicationClient cafe24ApplicationClient;
 	private final ShopAuthTokenService shopAuthTokenService;
 
 	@Override
@@ -32,6 +35,11 @@ public class Cafe24UseCaseImpl implements Cafe24UseCase {
 				throw e;
 			}
 		});
+	}
+
+	@Override
+	public String cafe24CreateScriptTag(String mallId, Cafe24CreateScriptTagRequest request) {
+		return cafe24ApplicationClient.createScriptTag(mallId, request.toCafe24CreateScriptTagDto());
 	}
 
 	private void updateShopAuthToken(Cafe24AccessToken cafe24AccessToken, ShopAuthToken shopAuthToken) {

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCaseImpl.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCaseImpl.java
@@ -1,11 +1,15 @@
 package com.romanticpipe.reviewcanvas.domain.shop.application.usecase;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.romanticpipe.reviewcanvas.cafe24.Cafe24FormUrlencodedFactory;
 import com.romanticpipe.reviewcanvas.cafe24.application.Cafe24ApplicationClient;
 import com.romanticpipe.reviewcanvas.cafe24.authentication.Cafe24AccessToken;
 import com.romanticpipe.reviewcanvas.cafe24.authentication.Cafe24AuthenticationClient;
 import com.romanticpipe.reviewcanvas.domain.ShopAuthToken;
 import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.request.Cafe24CreateScriptTagRequest;
+import com.romanticpipe.reviewcanvas.exception.BusinessException;
+import com.romanticpipe.reviewcanvas.exception.CommonErrorCode;
 import com.romanticpipe.reviewcanvas.service.ShopAuthTokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -20,6 +24,7 @@ public class Cafe24UseCaseImpl implements Cafe24UseCase {
 	private final Cafe24AuthenticationClient cafe24AuthenticationClient;
 	private final Cafe24ApplicationClient cafe24ApplicationClient;
 	private final ShopAuthTokenService shopAuthTokenService;
+	private final ObjectMapper objectMapper;
 
 	@Override
 	public void cafe24AuthenticationProcess(String mallId, String authCode) {
@@ -39,12 +44,21 @@ public class Cafe24UseCaseImpl implements Cafe24UseCase {
 
 	@Override
 	public String cafe24CreateScriptTag(String mallId, Cafe24CreateScriptTagRequest request) {
-		return cafe24ApplicationClient.createScriptTag(mallId, request.toCafe24CreateScriptTagDto());
+		String response = cafe24ApplicationClient.createScriptTag(mallId, request.toCafe24CreateScriptTagDto());
+		return getScriptNo(response);
 	}
 
 	private void updateShopAuthToken(Cafe24AccessToken cafe24AccessToken, ShopAuthToken shopAuthToken) {
 		String scope = String.join(",", cafe24AccessToken.scopes());
 		shopAuthToken.update(cafe24AccessToken.accessToken(), cafe24AccessToken.expiresAt(),
 			cafe24AccessToken.refreshToken(), cafe24AccessToken.refreshTokenExpiresAt(), scope);
+	}
+
+	private String getScriptNo(String response) {
+		try {
+			return objectMapper.readTree(response).path("scripttag").path("script_no").asText();
+		} catch (JsonProcessingException e) {
+			throw new BusinessException(CommonErrorCode.OUTER_CLIENT_REQUEST_ERROR);
+		}
 	}
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/request/Cafe24CreateScriptTagRequest.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/request/Cafe24CreateScriptTagRequest.java
@@ -1,0 +1,28 @@
+package com.romanticpipe.reviewcanvas.domain.shop.application.usecase.request;
+
+import com.romanticpipe.reviewcanvas.cafe24.application.Cafe24CreateScriptTagDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+@Schema(description = "카페24 스크립트 태그 생성 API request")
+public record Cafe24CreateScriptTagRequest(
+	@Schema(name = "원본 script 경로", description = "설치할 스크립트의 원본 경로(절대 경로)",
+		requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotBlank String src,
+	@Schema(name = "화면 경로",
+		description = "스크립트를 표시할 화면 경로. 화면 경로는 화면의 페이지 경로가 아니라 쇼핑몰의 각 페이지에 부여된 특정한 역할을 의미함",
+		requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotEmpty
+	List<String> displayLocation,
+	@Schema(description = "제외 경로", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+	List<String> excludeLocation,
+	@Schema(name = "스킨 번호", description = "스크립트를 적용할 스킨 번호", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+	List<Integer> skinNo
+) {
+	public Cafe24CreateScriptTagDto toCafe24CreateScriptTagDto() {
+		return Cafe24CreateScriptTagDto.of(src, displayLocation, excludeLocation, skinNo);
+	}
+}

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
@@ -5,6 +5,7 @@ import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.request.Caf
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.SchemaProperty;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,6 +15,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.Map;
 
 @Tag(name = "cafe24", description = "Cafe24 쇼핑몰 API")
 public interface Cafe24Api {
@@ -40,14 +43,21 @@ public interface Cafe24Api {
 	@ApiResponses(value = {
 		@ApiResponse(
 			responseCode = "200",
-			description = "cafe24 script tag 생성에 성공했습니다."),
+			description = "cafe24 script tag 생성에 성공했습니다.",
+			content = @Content(
+				schemaProperties = {
+					@SchemaProperty(name = "success", schema = @Schema(type = "boolean", description = "성공 여부")),
+					@SchemaProperty(name = "data", schema = @Schema(type = "object", contentSchema = Map.class,
+						defaultValue = "{\"scriptNo\": \"1527128695613925\"}"))
+				}
+			)),
 		@ApiResponse(
 			responseCode = "400",
 			description = "C003: 외부 API 호출 중 오류가 발생했습니다.",
 			content = @Content(schema = @Schema(hidden = true))),
 	})
 	@PostMapping("/cafe24/{mallId}/script-tag")
-	ResponseEntity<SuccessResponse<String>> cafe24CreateScriptTag(
+	ResponseEntity<SuccessResponse<Map<String, String>>> cafe24CreateScriptTag(
 		@Schema(name = "mall id", description = "쇼핑몰의 아이디") @PathVariable(required = true) String mallId,
 		@Valid @RequestBody Cafe24CreateScriptTagRequest request
 	);

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
@@ -1,15 +1,18 @@
 package com.romanticpipe.reviewcanvas.domain.shop.presentation.v1;
 
 import com.romanticpipe.reviewcanvas.common.dto.SuccessResponse;
+import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.request.Cafe24CreateScriptTagRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "cafe24", description = "Cafe24 쇼핑몰 API")
@@ -30,5 +33,22 @@ public interface Cafe24Api {
 	ResponseEntity<SuccessResponse<Void>> cafe24AuthenticationProcess(
 		@Schema(name = "mall id", description = "쇼핑몰의 아이디") @PathVariable(required = true) String mallId,
 		@Schema(name = "authorization code", description = "인증 코드") @RequestParam(required = true) String authCode
+	);
+
+	@Operation(summary = "cafe24 script tag 생성 api",
+		description = "https://developers.cafe24.com/docs/ko/api/admin/#create-a-script-tag 참고")
+	@ApiResponses(value = {
+		@ApiResponse(
+			responseCode = "200",
+			description = "cafe24 script tag 생성에 성공했습니다."),
+		@ApiResponse(
+			responseCode = "400",
+			description = "C003: 외부 API 호출 중 오류가 발생했습니다.",
+			content = @Content(schema = @Schema(hidden = true))),
+	})
+	@PostMapping("/cafe24/{mallId}/script-tag")
+	ResponseEntity<SuccessResponse<String>> cafe24CreateScriptTag(
+		@Schema(name = "mall id", description = "쇼핑몰의 아이디") @PathVariable(required = true) String mallId,
+		@Valid @RequestBody Cafe24CreateScriptTagRequest request
 	);
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Controller.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Controller.java
@@ -2,11 +2,14 @@ package com.romanticpipe.reviewcanvas.domain.shop.presentation.v1;
 
 import com.romanticpipe.reviewcanvas.common.dto.SuccessResponse;
 import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.Cafe24UseCase;
+import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.request.Cafe24CreateScriptTagRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,5 +30,17 @@ public class Cafe24Controller implements Cafe24Api {
 	) {
 		cafe24UseCase.cafe24AuthenticationProcess(mallId, authCode);
 		return SuccessResponse.ofNoData().asHttp(HttpStatus.OK);
+	}
+
+
+	@Override
+	@PostMapping("/cafe24/{mallId}/script-tag")
+	public ResponseEntity<SuccessResponse<String>> cafe24CreateScriptTag(
+		@PathVariable(required = true) String mallId,
+		@Valid @RequestBody Cafe24CreateScriptTagRequest request
+	) {
+		return SuccessResponse.of(
+			cafe24UseCase.cafe24CreateScriptTag(mallId, request)
+		).asHttp(HttpStatus.OK);
 	}
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Controller.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Controller.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 
 @RestController
 @RequestMapping("/api/v1")
@@ -35,12 +37,13 @@ public class Cafe24Controller implements Cafe24Api {
 
 	@Override
 	@PostMapping("/cafe24/{mallId}/script-tag")
-	public ResponseEntity<SuccessResponse<String>> cafe24CreateScriptTag(
+	public ResponseEntity<SuccessResponse<Map<String, String>>> cafe24CreateScriptTag(
 		@PathVariable(required = true) String mallId,
 		@Valid @RequestBody Cafe24CreateScriptTagRequest request
 	) {
+		String scriptNo = cafe24UseCase.cafe24CreateScriptTag(mallId, request);
 		return SuccessResponse.of(
-			cafe24UseCase.cafe24CreateScriptTag(mallId, request)
+			Map.of("scriptNo", scriptNo)
 		).asHttp(HttpStatus.OK);
 	}
 }

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24HttpExchangeConfig.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24HttpExchangeConfig.java
@@ -1,5 +1,6 @@
 package com.romanticpipe.reviewcanvas.cafe24;
 
+import com.romanticpipe.reviewcanvas.cafe24.application.Cafe24ApplicationClient;
 import com.romanticpipe.reviewcanvas.cafe24.authentication.Cafe24AuthenticationClient;
 import com.romanticpipe.reviewcanvas.cafe24.product.Cafe24ProductClient;
 import com.romanticpipe.reviewcanvas.config.RestClientLoggingInterceptor;
@@ -37,12 +38,29 @@ class Cafe24HttpExchangeConfig {
 	public Cafe24ProductClient cafe24ProductClient(
 		ClientHttpRequestFactory clientHttpRequestFactory, RestClientLoggingInterceptor restClientLoggingInterceptor,
 		Cafe24TokenInterceptor cafe24TokenInterceptor) {
-		RestClient restClient = RestClient.builder()
+		RestClient restClient = createRestClient(clientHttpRequestFactory, restClientLoggingInterceptor,
+			cafe24TokenInterceptor);
+
+		return getHttpExchange(restClient, Cafe24ProductClient.class);
+	}
+
+	@Bean
+	public Cafe24ApplicationClient cafe24ApplicationClient(
+		ClientHttpRequestFactory clientHttpRequestFactory, RestClientLoggingInterceptor restClientLoggingInterceptor,
+		Cafe24TokenInterceptor cafe24TokenInterceptor) {
+		RestClient restClient = createRestClient(clientHttpRequestFactory, restClientLoggingInterceptor,
+			cafe24TokenInterceptor);
+
+		return getHttpExchange(restClient, Cafe24ApplicationClient.class);
+	}
+
+	private RestClient createRestClient(ClientHttpRequestFactory clientHttpRequestFactory,
+										RestClientLoggingInterceptor restClientLoggingInterceptor,
+										Cafe24TokenInterceptor cafe24TokenInterceptor) {
+		return RestClient.builder()
 			.requestFactory(clientHttpRequestFactory)
 			.requestInterceptor(restClientLoggingInterceptor)
 			.requestInterceptor(cafe24TokenInterceptor)
 			.build();
-
-		return getHttpExchange(restClient, Cafe24ProductClient.class);
 	}
 }

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/application/Cafe24ApplicationClient.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/application/Cafe24ApplicationClient.java
@@ -1,0 +1,15 @@
+package com.romanticpipe.reviewcanvas.cafe24.application;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.HttpExchange;
+import org.springframework.web.service.annotation.PostExchange;
+
+@Component
+@HttpExchange("https://{mallId}.cafe24api.com/api/v2")
+public interface Cafe24ApplicationClient {
+
+	@PostExchange(value = "/admin/scripttags")
+	String createScriptTag(@PathVariable String mallId, @RequestBody Cafe24CreateScriptTagDto dto);
+}

--- a/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/application/Cafe24CreateScriptTagDto.java
+++ b/client-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/application/Cafe24CreateScriptTagDto.java
@@ -1,0 +1,31 @@
+package com.romanticpipe.reviewcanvas.cafe24.application;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.util.List;
+
+public record Cafe24CreateScriptTagDto(
+	Request request
+) {
+
+	public static Cafe24CreateScriptTagDto of(
+		String src,
+		List<String> displayLocation,
+		List<String> excludeLocation,
+		List<Integer> skinNo
+	) {
+		return new Cafe24CreateScriptTagDto(
+			new Request(src, displayLocation, excludeLocation, skinNo)
+		);
+	}
+
+	@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+	private record Request(
+		String src,
+		List<String> displayLocation,
+		List<String> excludeLocation,
+		List<Integer> skinNo
+	) {
+	}
+}


### PR DESCRIPTION
### 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

public view에서 원하는 SDK 사용을 위한 스크립트 설치를 제공하기 위해 cafe24 api를 호출해야 합니다. 따라서 백단에서 cafe24 api를 호출하여 script tag를 추가할 수 있도록 제공하는 api를 만들었습니다.

### ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

- [cafe24 script tag 생성 api] 생성

### 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?

- cafe24ApplicationClient 추가

### 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요

### 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?

