### PR TITLE
cafe24 authentication process api의 응답값에 shop admin의 상태를 추가한다

### DIFF
--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCase.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCase.java
@@ -3,7 +3,7 @@ package com.romanticpipe.reviewcanvas.domain.shop.application.usecase;
 import com.romanticpipe.reviewcanvas.domain.shop.application.usecase.request.Cafe24CreateScriptTagRequest;
 
 public interface Cafe24UseCase {
-	void cafe24AuthenticationProcess(String mallId, String authCode);
+	String cafe24AuthenticationProcess(String mallId, String authCode);
 
 	String cafe24CreateScriptTag(String mallId, Cafe24CreateScriptTagRequest request);
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCaseImpl.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/application/usecase/Cafe24UseCaseImpl.java
@@ -3,6 +3,7 @@ package com.romanticpipe.reviewcanvas.domain.shop.application.usecase;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.romanticpipe.reviewcanvas.admin.domain.ShopAuthToken;
+import com.romanticpipe.reviewcanvas.admin.service.ShopAdminReader;
 import com.romanticpipe.reviewcanvas.admin.service.ShopAuthTokenService;
 import com.romanticpipe.reviewcanvas.cafe24.Cafe24ErrorCode;
 import com.romanticpipe.reviewcanvas.cafe24.Cafe24FormUrlencodedFactory;
@@ -17,6 +18,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.MultiValueMap;
 
+import java.util.Optional;
+
 @Component
 @RequiredArgsConstructor
 public class Cafe24UseCaseImpl implements Cafe24UseCase {
@@ -25,20 +28,28 @@ public class Cafe24UseCaseImpl implements Cafe24UseCase {
 	private final Cafe24AuthenticationClient cafe24AuthenticationClient;
 	private final Cafe24ApplicationClient cafe24ApplicationClient;
 	private final ShopAuthTokenService shopAuthTokenService;
+	private final ShopAdminReader shopAdminReader;
 	private final ObjectMapper objectMapper;
 
 	@Override
-	public void cafe24AuthenticationProcess(String mallId, String authCode) {
+	public String cafe24AuthenticationProcess(String mallId, String authCode) {
 		MultiValueMap<String, String> requestParam = Cafe24FormUrlencodedFactory.getCafe24AccessToken(authCode);
 		Cafe24AccessToken cafe24AccessToken = cafe24AuthenticationClient.getAccessToken(mallId, requestParam);
 		if (!cafe24AccessToken.isFullContent()) {
 			throw new BusinessException(Cafe24ErrorCode.INVALID_ACCESS_TOKEN);
 		}
-		writeTransactionTemplate.executeWithoutResult(transactionStatus -> {
+		return writeTransactionTemplate.execute(transactionStatus -> {
 			try {
-				shopAuthTokenService.findByMallId(mallId)
-					.ifPresentOrElse(shopAuthToken -> updateShopAuthToken(cafe24AccessToken, shopAuthToken),
-						() -> shopAuthTokenService.save(cafe24AccessToken.toShopAuthToken()));
+				Optional<ShopAuthToken> shopAuthToken = shopAuthTokenService.findByMallId(mallId);
+				if (shopAuthToken.isPresent()) {
+					updateShopAuthToken(cafe24AccessToken, shopAuthToken.get());
+					return shopAdminReader.findByMallId(mallId)
+						.map(admin -> "REGISTERED")
+						.orElse("PREVIOUS_INSTALLED");
+				}
+
+				shopAuthTokenService.save(cafe24AccessToken.toShopAuthToken());
+				return "INSTALLED";
 			} catch (RuntimeException e) {
 				transactionStatus.setRollbackOnly();
 				throw e;

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
@@ -26,14 +26,24 @@ public interface Cafe24Api {
 	@ApiResponses(value = {
 		@ApiResponse(
 			responseCode = "200",
-			description = "성공적으로 인증 프로세스를 수행했습니다."),
+			description = "성공적으로 인증 프로세스를 수행했습니다.",
+			content = @Content(
+				schemaProperties = {
+					@SchemaProperty(name = "success", schema = @Schema(type = "boolean", description = "성공 여부")),
+					@SchemaProperty(name = "data", schema = @Schema(type = "object", contentSchema = Map.class,
+						defaultValue = "{\"shopAdminStatus\": \"INSTALLED\"}", allowableValues =
+						{"INSTALLED", "PREVIOUS_INSTALLED", "REGISTERED"}, description = "INSTALLED: 설치 완료, "
+						+ "PREVIOUS_INSTALLED: 이전에 설치된 상태, REGISTERED: 회원가입 완료됨, 참고로 이전에 설치된 상태나 " +
+						"회원가입 완료된 상태일 경우에도 cafe24 액세스 토큰을 발급받아 서버에 저장합니다."))
+				}
+			)),
 		@ApiResponse(
 			responseCode = "400",
 			description = "C003: 외부 API 호출 중 오류가 발생했습니다.",
 			content = @Content(schema = @Schema(hidden = true))),
 	})
 	@PostMapping("/cafe24/{mallId}/authentication-process")
-	ResponseEntity<SuccessResponse<Void>> cafe24AuthenticationProcess(
+	ResponseEntity<SuccessResponse<Map<String, String>>> cafe24AuthenticationProcess(
 		@Schema(name = "mall id", description = "쇼핑몰의 아이디") @PathVariable(required = true) String mallId,
 		@Schema(name = "authorization code", description = "인증 코드") @RequestParam(required = true) String authCode
 	);

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Api.java
@@ -33,8 +33,8 @@ public interface Cafe24Api {
 					@SchemaProperty(name = "data", schema = @Schema(type = "object", contentSchema = Map.class,
 						defaultValue = "{\"shopAdminStatus\": \"INSTALLED\"}", allowableValues =
 						{"INSTALLED", "PREVIOUS_INSTALLED", "REGISTERED"}, description = "INSTALLED: 설치 완료, "
-						+ "PREVIOUS_INSTALLED: 이전에 설치된 상태, REGISTERED: 회원가입 완료됨, 참고로 이전에 설치된 상태나 " +
-						"회원가입 완료된 상태일 경우에도 cafe24 액세스 토큰을 발급받아 서버에 저장합니다."))
+						+ "PREVIOUS_INSTALLED: 이전에 설치된 상태, REGISTERED: 회원가입 완료됨, 참고로 이전에 설치된 상태나 "
+						+ "회원가입 완료된 상태일 경우에도 cafe24 액세스 토큰을 발급받아 서버에 저장합니다."))
 				}
 			)),
 		@ApiResponse(

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Controller.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/shop/presentation/v1/Cafe24Controller.java
@@ -26,12 +26,15 @@ public class Cafe24Controller implements Cafe24Api {
 
 	@Override
 	@PostMapping("/cafe24/{mallId}/authentication-process")
-	public ResponseEntity<SuccessResponse<Void>> cafe24AuthenticationProcess(
+	public ResponseEntity<SuccessResponse<Map<String, String>>> cafe24AuthenticationProcess(
 		@PathVariable(required = true) String mallId,
 		@RequestParam(required = true) String authCode
 	) {
-		cafe24UseCase.cafe24AuthenticationProcess(mallId, authCode);
-		return SuccessResponse.ofNoData().asHttp(HttpStatus.OK);
+		;
+		String shopAdminStatus = cafe24UseCase.cafe24AuthenticationProcess(mallId, authCode);
+		return SuccessResponse.of(
+			Map.of("shopAdminStatus", shopAdminStatus)
+		).asHttp(HttpStatus.OK);
 	}
 
 

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/admin/domain/ShopAdmin.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/admin/domain/ShopAdmin.java
@@ -9,12 +9,14 @@ import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at is null")
 public class ShopAdmin extends BaseEntityWithUpdate implements Admin {
 
 	@Id

--- a/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/admin/service/ShopAdminReader.java
+++ b/domain-module/shopadmin/src/main/java/com/romanticpipe/reviewcanvas/admin/service/ShopAdminReader.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,7 +15,11 @@ public class ShopAdminReader {
 	private final ShopAdminRepository shopAdminRepository;
 
 
-	public List<ShopAdmin> findRegisteredShopAdmin() {
+	public List<ShopAdmin> findAll() {
 		return shopAdminRepository.findAll();
+	}
+
+	public Optional<ShopAdmin> findByMallId(String mallId) {
+		return shopAdminRepository.findByMallId(mallId);
 	}
 }

--- a/scheduler-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24ProductScheduler.java
+++ b/scheduler-module/src/main/java/com/romanticpipe/reviewcanvas/cafe24/Cafe24ProductScheduler.java
@@ -36,7 +36,7 @@ public class Cafe24ProductScheduler {
 	@Scheduled(cron = "${scheduler.update-product.cron}")
 	public void processUpdateProduct() {
 		log.info("product 정보 업데이트 scheduler 시작");
-		List<ShopAdmin> shopAdmins = shopAdminReader.findRegisteredShopAdmin();
+		List<ShopAdmin> shopAdmins = shopAdminReader.findAll();
 		shopAdmins.forEach(this::processEachShopAdmin);
 		log.info("product 정보 업데이트 scheduler 종료");
 	}


### PR DESCRIPTION
### 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

앱 인증 프로세스에서 app url 단에서 이미 설치가 되어 있다면 /auth/login으로 보내도록 구성하기 위해 앱 인증 프로세스 api 응답값에 shop admin의 상태를 추가합니다.