### PR TITLE
fix(RVCV-124): AccessPath에서 이메일 중복 체크 api url을 모두 삭제한다.

### DIFF
--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/common/security/AccessPath.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/common/security/AccessPath.java
@@ -1,12 +1,13 @@
 package com.romanticpipe.reviewcanvas.common.security;
 
-import lombok.Getter;
+import java.util.List;
+
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-import java.util.List;
+import lombok.Getter;
 
 @Component
 public final class AccessPath {
@@ -27,7 +28,6 @@ public final class AccessPath {
 		shopAdminAllowedPath.put("/api/v1/users/{userId}/reviews", List.of(HttpMethod.GET));
 		// shop-admin
 		shopAdminAllowedPath.put("/api/v1/shop-admin", List.of(HttpMethod.GET, HttpMethod.PATCH));
-		shopAdminAllowedPath.put("/api/v1/shop-admin/email-check", List.of(HttpMethod.GET));
 		// auth
 		shopAdminAllowedPath.put("/api/v1/logout", List.of(HttpMethod.POST));
 		shopAdminAllowedPath.put("/api/v1/auth/check", List.of(HttpMethod.GET));
@@ -53,7 +53,6 @@ public final class AccessPath {
 		// review
 		superAdminAllowedPath.put("/api/v1/users/{userId}/reviews", List.of(HttpMethod.GET));
 		// shop-admin
-		superAdminAllowedPath.put("/api/v1/shop-admin/email-check", List.of(HttpMethod.GET));
 		// auth
 		superAdminAllowedPath.put("/api/v1/logout", List.of(HttpMethod.POST));
 		superAdminAllowedPath.put("/api/v1/auth/check", List.of(HttpMethod.GET));


### PR DESCRIPTION
### 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

> api를 통해 이메일 중복체크 가능

### ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

> api url accessPath에서 삭제

### 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?

> 없습니다.

### 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요

> 없습니다.

### 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?

> 없습니다.
