### PR TITLE
fix: 리뷰 리스트 반환 시 자신이 좋아요를 누른 여부를 추가하여 반환하도록 수정한다

### DIFF
--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/review/application/usecase/ReviewUseCaseImpl.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/review/application/usecase/ReviewUseCaseImpl.java
@@ -39,6 +39,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -63,10 +64,11 @@ class ReviewUseCaseImpl implements ReviewUseCase {
 		).orElseGet(() -> productUseCase.createProduct(mallId, productNo));
 
 		return transactionUtils.executeInReadTransaction(
-			status -> reviewService.findAllByProductId(product.getId(), pageableRequest, filter)
-				.map(review -> this.convertGetReviewDetailResponse(review,
-					review.isThisUserReview(mallId, memberId), reviewLikeService.getReviewLikeCount(review.getId()),
-					memberId))
+			status -> {
+				User requestUser = userService.validByMemberIdAndMallId(memberId, mallId);
+				return reviewService.findAllByProductId(product.getId(), pageableRequest, filter)
+					.map(review -> this.convertGetReviewDetailResponse(review, requestUser));
+			}
 		);
 	}
 
@@ -75,18 +77,17 @@ class ReviewUseCaseImpl implements ReviewUseCase {
 	public PageResponse<GetReviewDetailResponse> getReviewsInMyPage(String mallId, String memberId,
 																	PageableRequest pageable,
 																	ReviewFilterForUser filter) {
-		User me = userService.validByMemberIdAndMallId(memberId, mallId);
-		return reviewService.getReviewsInMyPage(me.getId(), pageable, filter)
-			.map(review -> this.convertGetReviewDetailResponse(review, true,
-				reviewLikeService.getReviewLikeCount(review.getId()), memberId));
+		User requestUser = userService.validByMemberIdAndMallId(memberId, mallId);
+		return reviewService.getReviewsInMyPage(requestUser.getId(), pageable, filter)
+			.map(review -> this.convertGetReviewDetailResponse(review, requestUser));
 	}
 
 	@Override
 	@Transactional(readOnly = true)
 	public GetReviewDetailResponse getReviewForUser(Long reviewId, String mallId, String memberId) {
 		Review review = reviewService.validateById(reviewId);
-		return this.convertGetReviewDetailResponse(review, review.isThisUserReview(mallId, memberId),
-			reviewLikeService.getReviewLikeCount(review.getId()), memberId);
+		User requestUser = userService.validByMemberIdAndMallId(memberId, mallId);
+		return this.convertGetReviewDetailResponse(review, requestUser);
 	}
 
 	@Override
@@ -97,8 +98,7 @@ class ReviewUseCaseImpl implements ReviewUseCase {
 	) {
 		return reviewService.findAllByProductId(shopAdminId, productId, pageable, reviewPeriod, reviewFilters, score,
 				replyFilters)
-			.map(review -> this.convertGetReviewDetailResponse(review, false,
-				reviewLikeService.getReviewLikeCount(review.getId()), ""));
+			.map(review -> convertGetReviewDetailResponse(review, shopAdminId));
 	}
 
 	@Override
@@ -111,10 +111,9 @@ class ReviewUseCaseImpl implements ReviewUseCase {
 
 		return transactionUtils.executeInReadTransaction(
 			status -> {
-				User me = userService.validByMemberIdAndMallId(memberId, mallId);
-				return reviewService.getProductReviewsInMyPage(me.getId(), product.getId(), pageable, filter)
-					.map(review -> this.convertGetReviewDetailResponse(review, true,
-						reviewLikeService.getReviewLikeCount(review.getId()), memberId));
+				User requestUser = userService.validByMemberIdAndMallId(memberId, mallId);
+				return reviewService.getProductReviewsInMyPage(requestUser.getId(), product.getId(), pageable, filter)
+					.map(review -> this.convertGetReviewDetailResponse(review, requestUser));
 			});
 	}
 
@@ -243,16 +242,33 @@ class ReviewUseCaseImpl implements ReviewUseCase {
 		return reviewType;
 	}
 
-	private GetReviewDetailResponse convertGetReviewDetailResponse(Review review, boolean isMyReview, int likeCount,
-																   String memberId) {
+	private GetReviewDetailResponse convertGetReviewDetailResponse(Review review, User user) {
+		int reviewLikeCount = reviewLikeService.getReviewLikeCount(review.getId());
+		boolean isLikeThisReview = reviewLikeService.isUserLikeThisReview(review.getId(), user.getId());
+
+		return getGetReviewDetailResponse(review, Optional.of(user.getId()), reviewLikeCount, isLikeThisReview);
+	}
+
+	private GetReviewDetailResponse convertGetReviewDetailResponse(Review review, Integer shopAdminId) {
+		int reviewLikeCount = reviewLikeService.getReviewLikeCount(review.getId());
+		boolean isLikeThisReview = reviewLikeService.isShopAdminLikeThisReview(review.getId(), shopAdminId);
+
+		return getGetReviewDetailResponse(review, Optional.empty(), reviewLikeCount, isLikeThisReview);
+	}
+
+	private GetReviewDetailResponse getGetReviewDetailResponse(Review review, Optional<Long> requestUserId,
+															   int reviewLikeCount, boolean isLikeThisReview) {
 		if (review.getReviewType() == ReviewType.TEXT) {
-			return GetReviewDetailResponse.from(review, isMyReview, memberId, FileContentsResponse.empty(), likeCount);
+			return GetReviewDetailResponse.from(review, requestUserId, FileContentsResponse.empty(),
+				reviewLikeCount, isLikeThisReview);
 		}
 
 		List<String> objectKeys = Arrays.stream(review.getImageVideoUrls().split(",")).toList();
 		List<String> reviewFileUrls = s3Service.getReviewFileUrls(objectKeys);
 		List<String> reviewResizeImageUrls = s3Service.getReviewResizeImageUrls(objectKeys);
-		var fileContentsResponse = new FileContentsResponse(reviewFileUrls, reviewResizeImageUrls);
-		return GetReviewDetailResponse.from(review, isMyReview, memberId, fileContentsResponse, likeCount);
+		FileContentsResponse fileContentsResponse = new FileContentsResponse(reviewFileUrls, reviewResizeImageUrls);
+		return GetReviewDetailResponse.from(review, requestUserId, fileContentsResponse, reviewLikeCount,
+			isLikeThisReview);
 	}
+
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/review/presentation/v1/ReviewApi.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/review/presentation/v1/ReviewApi.java
@@ -45,7 +45,7 @@ interface ReviewApi {
 	ResponseEntity<SuccessResponse<PageResponse<GetReviewDetailResponse>>> getReviewsForUser(
 		@PathVariable("mallId") String mallId,
 		@PathVariable("productNo") Long productNo,
-		@RequestParam(value = "memberId", required = false) String memberId,
+		@RequestParam(value = "memberId") String memberId,
 		@RequestParam(value = "size", required = false, defaultValue = "20") int size,
 		@RequestParam(value = "page", required = false, defaultValue = "0") int page,
 		@RequestParam(name = "sort", required = false, defaultValue = "LATEST")

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/review/presentation/v1/ReviewController.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/review/presentation/v1/ReviewController.java
@@ -45,7 +45,7 @@ class ReviewController implements ReviewApi {
 	public ResponseEntity<SuccessResponse<PageResponse<GetReviewDetailResponse>>> getReviewsForUser(
 		@PathVariable("mallId") String mallId,
 		@PathVariable("productNo") Long productNo,
-		@RequestParam(value = "memberId", required = false) String memberId,
+		@RequestParam(value = "memberId") String memberId,
 		@RequestParam(value = "size", required = false, defaultValue = "10") int size,
 		@RequestParam(value = "page", required = false, defaultValue = "0") int page,
 		@RequestParam(name = "sort", required = false, defaultValue = "LATEST") ReviewSort sort,

--- a/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/domain/Review.java
+++ b/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/domain/Review.java
@@ -87,6 +87,10 @@ public class Review extends BaseEntityWithUpdate {
 		return user != null && Objects.equals(user.getMallId(), mallId) && Objects.equals(user.getMemberId(), memberId);
 	}
 
+	public boolean isThisUserReview(Long userId) {
+		return user != null && Objects.equals(user.getId(), userId);
+	}
+
 	public boolean isShopAdminReview() {
 		return shopAdminId != null;
 	}

--- a/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/repository/ReviewLikeRepository.java
+++ b/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/repository/ReviewLikeRepository.java
@@ -1,10 +1,9 @@
 package com.romanticpipe.reviewcanvas.repository;
 
-import java.util.Optional;
-
+import com.romanticpipe.reviewcanvas.domain.ReviewLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.romanticpipe.reviewcanvas.domain.ReviewLike;
+import java.util.Optional;
 
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
 
@@ -12,4 +11,7 @@ public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
 
 	Optional<ReviewLike> findByReviewIdAndUserIdAndShopAdminId(Long reviewId, Long userId, Integer shopAdminId);
 
+	boolean existsByReviewIdAndUserId(Long reviewId, Long userId);
+
+	boolean existsByReviewIdAndShopAdminId(Long reviewId, Integer shopAdminId);
 }

--- a/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/service/ReviewLikeService.java
+++ b/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/service/ReviewLikeService.java
@@ -1,16 +1,14 @@
 package com.romanticpipe.reviewcanvas.service;
 
-import org.springframework.stereotype.Service;
-
 import com.romanticpipe.reviewcanvas.domain.Review;
 import com.romanticpipe.reviewcanvas.domain.ReviewLike;
 import com.romanticpipe.reviewcanvas.domain.User;
 import com.romanticpipe.reviewcanvas.exception.BusinessException;
 import com.romanticpipe.reviewcanvas.exception.ReviewErrorCode;
 import com.romanticpipe.reviewcanvas.repository.ReviewLikeRepository;
-
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -48,5 +46,13 @@ public class ReviewLikeService {
 			reviewLikeRepository.findByReviewIdAndUserIdAndShopAdminId(reviewId, userId, shopAdminId)
 				.orElseThrow(() -> new BusinessException(ReviewErrorCode.ALREADY_UNLIKED_REVIEW))
 		);
+	}
+
+	public boolean isUserLikeThisReview(Long reviewId, Long userId) {
+		return reviewLikeRepository.existsByReviewIdAndUserId(reviewId, userId);
+	}
+
+	public boolean isShopAdminLikeThisReview(Long reviewId, Integer shopAdminId) {
+		return reviewLikeRepository.existsByReviewIdAndShopAdminId(reviewId, shopAdminId);
 	}
 }


### PR DESCRIPTION
### 변경사항

- 리뷰 리스트 반환하는 api(5개)에서 자신(user or shopadmin)이 리뷰에 좋아요를 누른 여부를 함께 반환하도록 변경한다
- public view 리뷰 리스트 조회 api에서 memberId를 꼭 받도록 변경한다