### PR TITLE
Review api를 요구사항에 맞게 수정한다.

### DIFF
--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/review/application/usecase/response/GetReviewDetailResponse.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/review/application/usecase/response/GetReviewDetailResponse.java
@@ -8,7 +8,6 @@ import lombok.Builder;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 @Builder
 @Schema(name = "GetReviewDetailResponse", description = "리뷰 및 댓글 조회 response")
@@ -47,18 +46,21 @@ public record GetReviewDetailResponse(
 	List<ReplyResponse> replies
 ) {
 
-	public static GetReviewDetailResponse from(Review review, Optional<Long> requestUserId,
-											   FileContentsResponse imageVideoUrls,
-											   int reviewLikeCount, boolean isLikeThisReview) {
+	public static GetReviewDetailResponse forUser(Review review, Long requestUserId,
+												  FileContentsResponse fileContentsResponse,
+												  int reviewLikeCount, boolean isLikeThisReview) {
+		boolean isThisRequestUserReview = !review.isShopAdminReview()
+			&& Objects.equals(requestUserId, review.getUser().getId());
+		String content = review.getDeletedAt() == null ? review.getContent() : " ";
 		var replyResponses = review.getReplyList().stream()
 			.map(reply -> createReplyResponse(requestUserId, reply))
 			.toList();
 
-		var responseBuilder = GetReviewDetailResponse.builder()
+		var builder = GetReviewDetailResponse.builder()
 			.reviewId(review.getId())
-			.content(review.getDeletedAt() == null ? review.getContent() : " ")
+			.content(content)
 			.score(review.getScore())
-			.isMine(requestUserId.map(review::isThisUserReview).orElse(false))
+			.isMine(isThisRequestUserReview)
 			.likeCount(reviewLikeCount)
 			.isLiked(isLikeThisReview)
 			.createAt(review.getCreatedAt())
@@ -66,24 +68,49 @@ public record GetReviewDetailResponse(
 			.deleted(review.getDeletedAt() != null)
 			.productId(review.getProduct().getId())
 			.productName(review.getProduct().getName())
-			.imageVideoUrls(imageVideoUrls)
+			.imageVideoUrls(fileContentsResponse)
 			.replies(replyResponses);
 
+		return addDetails(builder, review).build();
+	}
+
+	public static GetReviewDetailResponse forShopAdmin(Review review, FileContentsResponse fileContentsResponse,
+													   int reviewLikeCount, boolean isLikeThisReview) {
+		var replyResponses = review.getReplyList().stream()
+			.map(reply -> ReplyResponse.from(reply, false))
+			.toList();
+
+		var builder = GetReviewDetailResponse.builder()
+			.reviewId(review.getId())
+			.content(review.getContent())
+			.score(review.getScore())
+			.isMine(false)
+			.likeCount(reviewLikeCount)
+			.isLiked(isLikeThisReview)
+			.createAt(review.getCreatedAt())
+			.updatedAt(review.getUpdatedAt())
+			.deleted(review.getDeletedAt() != null)
+			.productId(review.getProduct().getId())
+			.productName(review.getProduct().getName())
+			.imageVideoUrls(fileContentsResponse)
+			.replies(replyResponses);
+
+		return addDetails(builder, review).build();
+	}
+
+	private static GetReviewDetailResponse.GetReviewDetailResponseBuilder addDetails(
+		GetReviewDetailResponse.GetReviewDetailResponseBuilder builder, Review review) {
 		if (review.isShopAdminReview()) {
-			responseBuilder.shopAdminId(review.getShopAdminId());
+			builder.shopAdminId(review.getShopAdminId());
 		} else {
-			responseBuilder
-				.userId(review.getUser().getId())
+			builder.userId(review.getUser().getId())
 				.nickname(review.getUser().getNickName());
 		}
-
-		return responseBuilder.build();
+		return builder;
 	}
 
-	private static ReplyResponse createReplyResponse(Optional<Long> requestUserId, Reply reply) {
-		return ReplyResponse.from(reply,
-			requestUserId.map(userId -> Objects.equals(userId, reply.getUser().getId())).orElse(false)
-		);
+	private static ReplyResponse createReplyResponse(Long requestUserId, Reply reply) {
+		boolean isRequestUserReply = Objects.equals(requestUserId, reply.getUser().getId());
+		return ReplyResponse.from(reply, isRequestUserReply);
 	}
-
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/review/application/usecase/response/GetReviewDetailResponse.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/review/application/usecase/response/GetReviewDetailResponse.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
+import java.util.Optional;
 
 @Builder
 @Schema(name = "GetReviewDetailResponse", description = "리뷰 및 댓글 조회 response")
@@ -46,11 +46,10 @@ public record GetReviewDetailResponse(
 	List<ReplyResponse> replies
 ) {
 
-	public static GetReviewDetailResponse forUser(Review review, Long requestUserId,
+	public static GetReviewDetailResponse forUser(Review review, Optional<Long> requestUserId,
 												  FileContentsResponse fileContentsResponse,
 												  int reviewLikeCount, boolean isLikeThisReview) {
-		boolean isThisRequestUserReview = !review.isShopAdminReview()
-			&& Objects.equals(requestUserId, review.getUser().getId());
+		boolean isThisRequestUserReview = requestUserId.map(review::isThisUserReview).orElse(false);
 		String content = review.getDeletedAt() == null ? review.getContent() : " ";
 		var replyResponses = review.getReplyList().stream()
 			.map(reply -> createReplyResponse(requestUserId, reply))
@@ -109,8 +108,8 @@ public record GetReviewDetailResponse(
 		return builder;
 	}
 
-	private static ReplyResponse createReplyResponse(Long requestUserId, Reply reply) {
-		boolean isRequestUserReply = Objects.equals(requestUserId, reply.getUser().getId());
+	private static ReplyResponse createReplyResponse(Optional<Long> requestUserId, Reply reply) {
+		boolean isRequestUserReply = requestUserId.map(reply::isThisUserReply).orElse(false);
 		return ReplyResponse.from(reply, isRequestUserReply);
 	}
 }

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/review/presentation/v1/ReviewApi.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/review/presentation/v1/ReviewApi.java
@@ -45,7 +45,7 @@ interface ReviewApi {
 	ResponseEntity<SuccessResponse<PageResponse<GetReviewDetailResponse>>> getReviewsForUser(
 		@PathVariable("mallId") String mallId,
 		@PathVariable("productNo") Long productNo,
-		@RequestParam(value = "memberId") String memberId,
+		@RequestParam(value = "memberId", required = false) String memberId,
 		@RequestParam(value = "size", required = false, defaultValue = "20") int size,
 		@RequestParam(value = "page", required = false, defaultValue = "0") int page,
 		@RequestParam(name = "sort", required = false, defaultValue = "LATEST")
@@ -85,7 +85,7 @@ interface ReviewApi {
 	@GetMapping("/reviews/{reviewId}")
 	ResponseEntity<SuccessResponse<GetReviewDetailResponse>> getReviewForUser(
 		@PathVariable Long reviewId,
-		@Schema(description = "내 리뷰인지 확인하기 위해 받는 파라미터") @RequestParam String memberId,
+		@Schema(description = "내 리뷰인지 확인하기 위해 받는 파라미터") @RequestParam(required = false) String memberId,
 		@Schema(description = "내 리뷰인지 확인하기 위해 받는 파라미터") @RequestParam String mallId);
 
 	@Operation(summary = "shop admin 대시보드 리뷰 조회 API", description = "shop admin 대시보드에서 리뷰를 조회한다.",

--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/review/presentation/v1/ReviewController.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/review/presentation/v1/ReviewController.java
@@ -45,7 +45,7 @@ class ReviewController implements ReviewApi {
 	public ResponseEntity<SuccessResponse<PageResponse<GetReviewDetailResponse>>> getReviewsForUser(
 		@PathVariable("mallId") String mallId,
 		@PathVariable("productNo") Long productNo,
-		@RequestParam(value = "memberId") String memberId,
+		@RequestParam(value = "memberId", required = false) String memberId,
 		@RequestParam(value = "size", required = false, defaultValue = "10") int size,
 		@RequestParam(value = "page", required = false, defaultValue = "0") int page,
 		@RequestParam(name = "sort", required = false, defaultValue = "LATEST") ReviewSort sort,
@@ -72,7 +72,7 @@ class ReviewController implements ReviewApi {
 	@Override
 	@GetMapping("/reviews/{reviewId}")
 	public ResponseEntity<SuccessResponse<GetReviewDetailResponse>> getReviewForUser(
-		@PathVariable Long reviewId, @RequestParam String memberId, @RequestParam String mallId) {
+		@PathVariable Long reviewId, @RequestParam(required = false) String memberId, @RequestParam String mallId) {
 		return SuccessResponse.of(
 			reviewUseCase.getReviewForUser(reviewId, mallId, memberId)
 		).asHttp(HttpStatus.OK);

--- a/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/domain/Reply.java
+++ b/domain-module/review/src/main/java/com/romanticpipe/reviewcanvas/domain/Reply.java
@@ -50,4 +50,8 @@ public class Reply extends BaseEntityWithUpdate {
 	public void delete() {
 		this.deletedAt = LocalDateTime.now();
 	}
+
+	public boolean isThisUserReply(Long userId) {
+		return user != null && user.getId().equals(userId);
+	}
 }


### PR DESCRIPTION
### 변경사항

- shop admin 대시보드 api의 응답에 삭제된 리뷰의 content를 포함하도록 변경
- public view 리뷰 리스트 조회, public view 리뷰 조회 api에서 memberId를 필수로 받지 않도록 변경(shop에 로그인하지 않은 유저도 리뷰를 볼 수 있어야 하기 때문입니다)