### PR TITLE
public view 리뷰 리스트 및 리뷰 조회 api에서 memberId에 해당하는 유저가 없어도 리뷰가 조회되도록 수정한다

### DIFF
--- a/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/review/application/usecase/ReviewUseCaseImpl.java
+++ b/api-module/src/main/java/com/romanticpipe/reviewcanvas/domain/review/application/usecase/ReviewUseCaseImpl.java
@@ -277,7 +277,7 @@ class ReviewUseCaseImpl implements ReviewUseCase {
 
 	private Optional<Long> getRequestUserId(String memberId, String mallId) {
 		if (StringUtils.hasText(memberId)) {
-			return Optional.of(userService.validByMemberIdAndMallId(memberId, mallId).getId());
+			return userService.findUser(memberId, mallId).map(User::getId);
 		}
 		return Optional.empty();
 	}


### PR DESCRIPTION
### 변경사항

public view 리뷰 리스트 조회 api 및 public view 리뷰 조회 api에서 mallId, memberId에 해당하는 유저가 없어도 리뷰가 조회되도록 수정